### PR TITLE
add support stdClass objects from Db queries

### DIFF
--- a/src/Utils/Transformers/WithCustomTransformers.php
+++ b/src/Utils/Transformers/WithCustomTransformers.php
@@ -6,6 +6,7 @@ use Closure;
 use Code16\Sharp\Form\SharpForm;
 use Illuminate\Contracts\Pagination\LengthAwarePaginator as LengthAwarePaginatorContract;
 use Illuminate\Pagination\LengthAwarePaginator;
+use stdClass;
 
 /**
  * This trait allows a class to handle a custom transformers array.
@@ -98,7 +99,7 @@ trait WithCustomTransformers
      */
     protected function applyTransformers($model, bool $forceFullObject = true)
     {
-        $attributes = is_array($model) ? $model : $model->toArray();
+        $attributes = is_array($model) ? $model: ($model instanceof stdClass ? (array)$model: $model->toArray());
 
         if($forceFullObject) {
             // Merge model attribute with form fields to be sure we have

--- a/tests/Unit/EntityList/WithCustomTransformersInEntityListTest.php
+++ b/tests/Unit/EntityList/WithCustomTransformersInEntityListTest.php
@@ -9,6 +9,7 @@ use Code16\Sharp\Tests\Fixtures\Person;
 use Code16\Sharp\Tests\Unit\Form\Eloquent\SharpFormEloquentBaseTest;
 use Code16\Sharp\Utils\Transformers\SharpAttributeTransformer;
 use Code16\Sharp\Utils\Transformers\WithCustomTransformers;
+use Illuminate\Support\Facades\DB;
 
 class WithCustomTransformersInEntityListTest extends SharpFormEloquentBaseTest
 {
@@ -23,6 +24,49 @@ class WithCustomTransformersInEntityListTest extends SharpFormEloquentBaseTest
         $this->assertArraySubset(
             [["name" => "John Wayne"], ["name" => "Mary Wayne"]],
             $list->getListData(new EntityListQueryParams())
+        );
+    }
+    
+    /** @test */
+    function we_can_retrieve_an_array_version_of_a_db_raw_collection()
+    {
+        Person::create(["name" => "John Wayne"]);
+        Person::create(["name" => "Mary Wayne"]);
+        
+        $list = new class extends WithCustomTransformersTestList
+        {
+            function getListData(EntityListQueryParams $params)
+            {
+                return $this->transform(DB::table((new Person())->getTable())->get());
+            }
+        };
+    
+        $this->assertArraySubset(
+            [["name" => "John Wayne"], ["name" => "Mary Wayne"]],
+            $list->getListData(new EntityListQueryParams())
+        );
+    }
+    
+    /** @test */
+    function we_can_retrieve_an_array_version_of_a_db_raw_paginator()
+    {
+        Person::create(["name" => "A"]);
+        Person::create(["name" => "B"]);
+        Person::create(["name" => "C"]);
+        Person::create(["name" => "D"]);
+        Person::create(["name" => "E"]);
+        
+        $list = new class extends WithCustomTransformersTestList
+        {
+            function getListData(EntityListQueryParams $params)
+            {
+                return $this->transform(DB::table((new Person())->getTable())->paginate(2));
+            }
+        };
+        
+        $this->assertArraySubset(
+            [["name" => "A"], ["name" => "B"]],
+            $list->getListData(new EntityListQueryParams())->items()
         );
     }
 

--- a/tests/Unit/Form/WithCustomTransformersInFormTest.php
+++ b/tests/Unit/Form/WithCustomTransformersInFormTest.php
@@ -9,6 +9,7 @@ use Code16\Sharp\Tests\Fixtures\Person;
 use Code16\Sharp\Tests\Unit\Form\Eloquent\SharpFormEloquentBaseTest;
 use Code16\Sharp\Utils\Transformers\SharpAttributeTransformer;
 use Code16\Sharp\Utils\Transformers\WithCustomTransformers;
+use Illuminate\Support\Facades\DB;
 
 class WithCustomTransformersInFormTest extends SharpFormEloquentBaseTest
 {
@@ -27,7 +28,26 @@ class WithCustomTransformersInFormTest extends SharpFormEloquentBaseTest
             ], $form->find($person->id)
         );
     }
-
+    /** @test */
+    function we_can_retrieve_an_array_version_of_a_stdclass()
+    {
+        $person = Person::create([
+            "name" => "John Wayne"
+        ]);
+        $form = new class extends WithCustomTransformersTestForm
+        {
+            function find($id): array
+            {
+                return $this->transform(
+                    DB::table((new Person())->getTable())->where(['id'=>$id])->first()
+                );
+            }
+        };
+        $this->assertArraySubset([
+            "name" => "John Wayne"
+        ], $form->find($person->id)
+        );
+    }
     /** @test */
     function belongsTo_is_handled()
     {


### PR DESCRIPTION
This allow to use db query results without eloquent (prevent "Call to undefined method stdClass::toArray()" error)

With this fix we able to use

```php
//SharpEntityList child
 function getListData(EntityListQueryParams $params)
    {
        $logs = DB::table('logs')->orderBy($params->sortedBy() , $params->sortedDir());
       //....
        return  $this->setCustomTransformer('level', LevelTransformer::class)
            ->transform($logs->paginate($params->filterFor('perpage')));
   }

```

 ```php
//SharpForm child
function find($id): array
    {
        return $this->setCustomTransformer('is_read', BooleanTransformer::class)
            ->setCustomTransformer('level', LevelTransformer::class)
            ->transform(
                DB::table('logs')->where(['id' => $id])->limit(1)->first()
            );
    }
```