### PR TITLE
Fix compatibility with laravel's ValidationException

### DIFF
--- a/src/Form/Validator/SharpValidator.php
+++ b/src/Form/Validator/SharpValidator.php
@@ -13,10 +13,12 @@ class SharpValidator extends Validator
 {
 
     /**
-     * @return MessageBag
+     * @return bool
      */
-    public function messages()
+    public function passes()
     {
+        $result = parent::passes();
+
         // First grab all messages which do not refer to a Rich Text Field (RTF)
         $newMessages = collect($this->messages->getMessages())->filter(function($messages, $key) {
             return !ends_with($key, ".text");
@@ -34,6 +36,8 @@ class SharpValidator extends Validator
                 });
             });
 
-        return new MessageBag($newMessages);
+        $this->messages = new MessageBag($newMessages);
+
+        return $result;
     }
 }

--- a/tests/Unit/Form/Validator/SharpValidatorTest.php
+++ b/tests/Unit/Form/Validator/SharpValidatorTest.php
@@ -4,6 +4,7 @@ namespace Code16\Sharp\Tests\Unit\Form\Validator;
 
 use Code16\Sharp\Form\Validator\SharpValidator;
 use Code16\Sharp\Tests\SharpTestCase;
+use Illuminate\Validation\ValidationException;
 
 class SharpValidatorTest extends SharpTestCase
 {
@@ -44,5 +45,15 @@ class SharpValidatorTest extends SharpTestCase
         $validator->passes();
 
         $this->assertEquals(["name" => ["The name field is required."]], $validator->messages()->toArray());
+    }
+
+    /** @test */
+    function compatible_with_laravel_validation_exception()
+    {
+        $exception = ValidationException::withMessages([
+            "name" => ["Test"]
+        ]);
+
+        $this->assertEquals(["name" => ["Test"]], $exception->errors());
     }
 }


### PR DESCRIPTION
When using [ValidationException::withMessages](https://laravel.com/api/5.7/Illuminate/Validation/ValidationException.html#method_withMessages) and sharp's validator is being used, then the code will error out due to `$this->messages` not being set (Call to a member function getMessages() on null) as it doesn't call passes() first.

Laravel's Validator messages() method calls passes() if $this->messages isn't set, and since ValidationException::withMessages expects MessageBag to stay the same I moved the modifications to the end of passes method (only time when $this->messages is set)