### PR TITLE
Default value for custom_url_segment in layout

### DIFF
--- a/resources/views/layout.blade.php
+++ b/resources/views/layout.blade.php
@@ -3,7 +3,7 @@
 <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-    <meta name="base-url" content="{{ config('sharp.custom_url_segment') }}">
+    <meta name="base-url" content="{{ config('sharp.custom_url_segment', 'sharp') }}">
     <title>{{ sharp_page_title($sharpMenu ?? null, $entityKey ?? $dashboardKey ?? null) }}</title>
     <link rel="stylesheet" href="/vendor/sharp/sharp.css?version={{ sharp_version() }}">
     <link rel="stylesheet" href="/vendor/sharp/sharp-cms.css?version={{ sharp_version() }}">


### PR DESCRIPTION
There should be a fallback value for config `custom_url_segment` in `layout.blade.php`.
I upgraded to latest version, and did not have this config defined in `sharp.php`. It broke the application and I started getting JS errors and no records loaded on the view.