### PR TITLE
Allow default thumbnail size to be defined in settings

### DIFF
--- a/src/Form/Eloquent/Transformers/FormUploadModelTransformer.php
+++ b/src/Form/Eloquent/Transformers/FormUploadModelTransformer.php
@@ -46,7 +46,7 @@ class FormUploadModelTransformer implements SharpAttributeTransformer
     {
         return ($upload->file_name ? [
                 "name" => $upload->file_name,
-                "thumbnail" => $upload->thumbnail(1000, 400),
+                "thumbnail" => $upload->thumbnail(config("sharp.uploads.default_thumbnail.width", 1000), config("sharp.uploads.default_thumbnail.height", 400)),
                 "size" => $upload->size,
             ] : [])
             + ($upload->custom_properties ?? [])


### PR DESCRIPTION
The default thumbnail size of 1000x400 wasn't right for me, it seems to me like this should be configurable, so added a config value to set the size of the initially generated thumbnail on upload. 