### PR TITLE
Added "deleteSharpForm" helper

### DIFF
--- a/src/Utils/Testing/SharpAssertions.php
+++ b/src/Utils/Testing/SharpAssertions.php
@@ -87,6 +87,18 @@ trait SharpAssertions
 
     /**
      * @param string $entityKey
+     * @param $instanceId
+     * @return mixed
+     */
+    protected function deleteSharpForm(string $entityKey, $instanceId)
+    {
+        return $this->deleteJson(
+            route("code16.sharp.api.form.delete", [$entityKey, $instanceId])
+        );
+    }
+
+    /**
+     * @param string $entityKey
      * @param mixed|null $instanceId
      * @return mixed
      */


### PR DESCRIPTION
Added the "deleteSharpForm" helper so that during testing, the SUT can call delete on an entity through Sharp and the developer can test / spy on any followup actions during deletion. 

PS. If testing need to be added, let me know and I will add it. :)