### PR TITLE
Use config sharp.name in login title

### DIFF
--- a/resources/views/login.blade.php
+++ b/resources/views/login.blade.php
@@ -9,7 +9,7 @@
                 <div class="row justify-content-center">
                     <div class="col-sm-9 col-md-6 col-lg-5 col-xl-4">
 
-                        <h1 class="text-center mb-3">{{config('sharp.name')}}</h1>
+                        <h1 class="text-center mb-3">{{config("sharp.name", "Sharp")}}</h1>
 
                         @if ($errors->any())
 

--- a/resources/views/login.blade.php
+++ b/resources/views/login.blade.php
@@ -9,7 +9,7 @@
                 <div class="row justify-content-center">
                     <div class="col-sm-9 col-md-6 col-lg-5 col-xl-4">
 
-                        <h1 class="text-center mb-3">Sharp</h1>
+                        <h1 class="text-center mb-3">{{config('sharp.name')}}</h1>
 
                         @if ($errors->any())
 
@@ -48,6 +48,7 @@
                                 </div>
                             </div>
                         </div>
+                        <p class="text-center mt-3">with <a href="https://sharp.code16.fr/docs/">Sharp {{sharp_version()}}</a></p>
 
                     </div>
                 </div>


### PR DESCRIPTION
solves / draft for https://github.com/code16/sharp/issues/131

- config/sharp.php `'name' => 'Saturn Spaceships'`
- if no value is provided 'Sharp' is being displayed

![20191001-20_26_48-Login _ Sharp 4 1 19](https://user-images.githubusercontent.com/122098/65989661-64d7e100-e48a-11e9-9240-858399dff656.png)
