### PR TITLE
Fixes documentation for generating command class

### DIFF
--- a/docs/guide/commands.md
+++ b/docs/guide/commands.md
@@ -4,11 +4,18 @@ Commands in Sharp are a powerful way to integrate functional processes in the co
 
 Commands can be defined in an EntityList or in a Dashboard. This documentation will take the EntityList case, but the API is very similar in both cases, as explained at the end of this page.
 
-## Generator
+## Generator for an 'EntityList' command
 
 ```bash
-php artisan sharp:make:entity-command <class_name> [--model=<model_name>]
+php artisan sharp:make:entity-command <class_name>
 ```
+
+## Generator for an 'Instance' command
+
+```bash
+php artisan sharp:make:instance-command <class_name>
+```
+
 
 ## Write the Command class
 


### PR DESCRIPTION
Just recognized that the command shown in the documentation doesn't exist (or maybe anymore).
As the guide uses the example of an entity list command I changed the page for that.
It changes "sharp:make:list-command" to "sharp:make:entity-command" as "list-command" doesn't exist in the current version (4.1.6).