### PR TITLE
Use Storage Disk to write thumbnail

### DIFF
--- a/src/Form/Eloquent/Uploads/Thumbnails/Thumbnail.php
+++ b/src/Form/Eloquent/Uploads/Thumbnails/Thumbnail.php
@@ -152,7 +152,7 @@ class Thumbnail
                     });
                 }
 
-                $sourceImg->save($thumbnailDisk->path($thumbName), $this->quality);
+                $thumbnailDisk->put($thumbName, $sourceImg->stream(null, $this->quality));
 
             } catch(FileNotFoundException $ex) {
                 return null;
@@ -162,7 +162,7 @@ class Thumbnail
             }
         }
 
-        return $thumbnailDisk->url($thumbName) . ($this->appendTimestamp ? "?" . filectime($thumbnailDisk->path($thumbName)) : "");
+        return $thumbnailDisk->url($thumbName) . ($this->appendTimestamp ? "?" . $thumbnailDisk->lastModified($thumbName) : "");
     }
 
     /**


### PR DESCRIPTION
Intervention\Image::save() is not compatible with Flysystem's disks. It only works with local paths. When using an S3 disk, the thumbnail method fails.  This hotfix fixes this issue.