### PR TITLE
feat: add collapsable on entity list section

### DIFF
--- a/src/Show/Layout/ShowLayout.php
+++ b/src/Show/Layout/ShowLayout.php
@@ -20,9 +20,10 @@ class ShowLayout implements HasLayout
         return $this;
     }
 
-    final public function addEntityListSection(string $entityListKey, \Closure $callback = null): self
+    final public function addEntityListSection(string $entityListKey, \Closure $callback = null, bool $collapsable = false): self
     {
         $section = new ShowLayoutSection('');
+        $section->setCollapsable($collapsable);
         $section->addColumn(12, function ($column) use ($entityListKey) {
             $column->withSingleField($entityListKey);
         });


### PR DESCRIPTION
When I use Sharp framework, sometimes I need to collapse a section on the entity show page. 

For example, I have this following code to show tags relation between servers and tags.

With PHP 8 and arrow function is okay, but with PHP version older than 8, the code can be really more, more, more, long.

```php
class ServerEntityShow extends SharpShow
{
    protected function buildShowFields(FieldsContainer $showFields): void
    {
        $showFields
            ->addField(
                SharpShowEntityListField::make('tags', 'tag')
                    ->setLabel('Tags')
            );
    }
    
    protected function buildShowLayout(ShowLayout $showLayout): void
    {
        $showLayout

            // On current sharp version 
            ->addEntityListSection('tags', function(ShowLayoutSection $section) { 
                $section->setCollapsable()
            })

            // With the pull request
            // The third parameter as default "false", it represent $collapsable boolean
            ->addEntityListSection('tags', null, true);
    }
    
}
```