### PR TITLE
[DOCS] Add a return type to function

### DIFF
--- a/docs/guide/commands.md
+++ b/docs/guide/commands.md
@@ -65,7 +65,7 @@ Here we get an `$instanceId` parameter to identify the exact instance involved. 
 The second parameter in the `execute()` function is an array named `$data`, which contains values entered by the user in a Command specific form. A use case might be to allow the user to enter a text to be sent to the customer with his invoice. In order to do that, we have first to write a `buildFormFields()` function in the Command class:
 
 ```php
-function buildFormFields(FieldsContainer $formFields)
+function buildFormFields(FieldsContainer $formFields): void
 {
     $formFields
         ->addField(


### PR DESCRIPTION
I'm copying examples sometimes, and PHPStan complains it does not have a return type compatible with `InstanceCommand`