### PR TITLE
Allow float numbers for Number field

### DIFF
--- a/demo/app/Sharp/TestForm/TestForm.php
+++ b/demo/app/Sharp/TestForm/TestForm.php
@@ -153,8 +153,9 @@ class TestForm extends SharpSingleForm
             ->addField(
                 SharpFormNumberField::make('number')
                     ->setLabel('Number')
-                ->setMin(1)
-                ->setMax(100),
+                    ->setMin(0)
+                    ->setMax(1)
+                    ->setStep(.1),
             )
             ->addField(
                 SharpFormSelectField::make('select_dropdown', $this->options(true))

--- a/src/Form/Fields/Formatters/NumberFormatter.php
+++ b/src/Form/Fields/Formatters/NumberFormatter.php
@@ -13,7 +13,7 @@ class NumberFormatter extends SharpFieldFormatter
      */
     public function toFront(SharpFormField $field, $value)
     {
-        return (int) $value;
+        return (float) $value;
     }
 
     /**

--- a/src/Form/Fields/SharpFormNumberField.php
+++ b/src/Form/Fields/SharpFormNumberField.php
@@ -11,9 +11,9 @@ class SharpFormNumberField extends SharpFormField
 
     const FIELD_TYPE = 'number';
 
-    protected ?int $min = null;
-    protected ?int $max = null;
-    protected int $step = 1;
+    protected ?float $min = null;
+    protected ?float $max = null;
+    protected float $step = 1;
     protected bool $showControls = false;
 
     public static function make(string $key): self
@@ -21,21 +21,21 @@ class SharpFormNumberField extends SharpFormField
         return new static($key, static::FIELD_TYPE, new NumberFormatter);
     }
 
-    public function setMin(int $min): self
+    public function setMin(float $min): self
     {
         $this->min = $min;
 
         return $this;
     }
 
-    public function setMax(int $max): self
+    public function setMax(float $max): self
     {
         $this->max = $max;
 
         return $this;
     }
 
-    public function setStep(int $step): self
+    public function setStep(float $step): self
     {
         $this->step = $step;
 
@@ -52,9 +52,9 @@ class SharpFormNumberField extends SharpFormField
     protected function validationRules(): array
     {
         return [
-            'min' => 'integer',
-            'max' => 'integer',
-            'step' => 'required|integer',
+            'min' => 'numeric',
+            'max' => 'numeric',
+            'step' => 'required|numeric',
             'showControls' => 'required|bool',
         ];
     }


### PR DESCRIPTION
With this PR you can now use the number field instead of the Text field for decimal numbers. The HTML `"number"` input accepts comma/dot format.

Closes https://github.com/code16/sharp-dev/issues/236