### PR TITLE
Prevent commands to be sent as JSON object

### DIFF
--- a/src/EntityList/Traits/Utils/CommonCommandUtils.php
+++ b/src/EntityList/Traits/Utils/CommonCommandUtils.php
@@ -27,6 +27,7 @@ trait CommonCommandUtils
                 ];
             });
 
+        // force JSON arrays when groupIndex starts at 1 (https://github.com/code16/sharp-dev/issues/33)
         if($config['commands'] ?? null) {
             $config['commands'] = collect($config['commands'])
                 ->map(fn ($group) => collect($group)->values())

--- a/src/EntityList/Traits/Utils/CommonCommandUtils.php
+++ b/src/EntityList/Traits/Utils/CommonCommandUtils.php
@@ -26,5 +26,11 @@ trait CommonCommandUtils
                         : $handler->getGlobalAuthorization(),
                 ];
             });
+
+        if($config['commands'] ?? null) {
+            $config['commands'] = collect($config['commands'])
+                ->map(fn ($group) => collect($group)->values())
+                ->toArray();
+        }
     }
 }

--- a/src/EntityList/Traits/Utils/CommonCommandUtils.php
+++ b/src/EntityList/Traits/Utils/CommonCommandUtils.php
@@ -27,7 +27,7 @@ trait CommonCommandUtils
                 ];
             });
 
-        if($config['commands'] ?? null) {
+        if ($config['commands'] ?? null) {
             $config['commands'] = collect($config['commands'])
                 ->map(fn ($group) => collect($group)->values())
                 ->toArray();


### PR DESCRIPTION
Prevent commands to be sent as object when there is leading command separators.

closes https://github.com/code16/sharp-dev/issues/33