### PR TITLE
Fix UTF-8 mangling by editor field

### DIFF
--- a/src/Form/Fields/Formatters/EditorFormatter.php
+++ b/src/Form/Fields/Formatters/EditorFormatter.php
@@ -35,7 +35,7 @@ class EditorFormatter extends SharpFieldFormatter
                 ->toArray();
         }
 
-        return preg_replace('/\R/', "\n", $this->handleUploadedFiles($content, $files, $field, $attribute));
+        return preg_replace('/\R/u', "\n", $this->handleUploadedFiles($content, $files, $field, $attribute));
     }
 
     protected function handleUploadedFiles(string $text, array $files, SharpFormField $field, string $attribute): string

--- a/tests/Unit/Form/Fields/Formatters/EditorFormatterTest.php
+++ b/tests/Unit/Form/Fields/Formatters/EditorFormatterTest.php
@@ -51,6 +51,23 @@ class EditorFormatterTest extends SharpTestCase
     }
 
     /** @test */
+    public function we_can_format_a_unicode_text_value_from_front()
+    {
+        // This test was created to demonstrate preg_replace failure
+        // The correct way is to use mb_ereg_replace
+        $value = '<p>ąężółść</p>';
+
+        $this->assertEquals(
+            $value,
+            (new EditorFormatter)->fromFront(
+                SharpFormEditorField::make('md'),
+                'attribute',
+                ['text' => $value],
+            ),
+        );
+    }
+
+    /** @test */
     public function we_store_newly_uploaded_files_from_front()
     {
         app()->bind(UploadFormatter::class, function () {

--- a/tests/Unit/Form/Fields/Formatters/EditorFormatterTest.php
+++ b/tests/Unit/Form/Fields/Formatters/EditorFormatterTest.php
@@ -54,7 +54,7 @@ class EditorFormatterTest extends SharpTestCase
     public function we_can_format_a_unicode_text_value_from_front()
     {
         // This test was created to demonstrate preg_replace failure
-        // The correct way is to use mb_ereg_replace
+        // without the unicode modifier
         $value = '<p>ąężółść</p>';
 
         $this->assertEquals(


### PR DESCRIPTION
The editor field mangles the Polish `ą` character (and I suspect some other characters too).

I have added PCRE modifier `u` so that it works correctly on UTF-8 characters.

I have also added the test demonstrating the failure:

```
1) Code16\Sharp\Tests\Unit\Form\Fields\Formatters\EditorFormatterTest::we_can_format_a_unicode_text_value_from_front
Failed asserting that two strings are equal.
--- Expected
+++ Actual
@@ @@
-'<p>ąężółść</p>'
+'<p>?\n
+ężółść</p>'

```

(Another option I considered was switching to `mb_ereg_replace`, but that introduces dependency on `mbstring` extension, so I leave it up to you).

Please merge ASAP, I'd like to continue using vanilla upstream ;)
This bug was found after migration from v6.