### PR TITLE
Upload: Handle default transformKeepOriginal in config

### DIFF
--- a/config/config.php
+++ b/config/config.php
@@ -53,7 +53,7 @@ return [
         // These two configs are used for thumbnail generation inside Sharp.
         'thumbnails_disk' => env('SHARP_UPLOADS_THUMBS_DISK', 'public'),
         'thumbnails_dir' => env('SHARP_UPLOADS_THUMBS_DIR', 'thumbnails'),
-        
+
         'transform_keep_original_image' => true,
     ],
 

--- a/config/config.php
+++ b/config/config.php
@@ -53,6 +53,8 @@ return [
         // These two configs are used for thumbnail generation inside Sharp.
         'thumbnails_disk' => env('SHARP_UPLOADS_THUMBS_DISK', 'public'),
         'thumbnails_dir' => env('SHARP_UPLOADS_THUMBS_DIR', 'thumbnails'),
+        
+        'transform_keep_original_image' => true,
     ],
 
     // Optional. Options for form markdown editor (SharpFormMarkdownField)

--- a/demo/config/sharp.php
+++ b/demo/config/sharp.php
@@ -22,6 +22,7 @@ return [
         'tmp_dir' => env('SHARP_UPLOADS_TMP_DIR', 'tmp'),
         'thumbnails_disk' => env('SHARP_UPLOADS_THUMBS_DISK', 'public'),
         'thumbnails_dir' => env('SHARP_UPLOADS_THUMBS_DIR', 'thumbnails'),
+        'transform_keep_original_image' => true,
     ],
 
     'auth' => [

--- a/docs/guide/form-fields/upload.md
+++ b/docs/guide/form-fields/upload.md
@@ -25,9 +25,17 @@ This `tmp_dir` path is relative to the `local` filesystem defined in the Laravel
 
 Max file size allowed.
 
-### `setTransformable(bool $transformable = true, bool $transformKeepOriginal = true)`
+### `setTransformable(bool $transformable = true, ?bool $transformKeepOriginal = null)`
 
 Allow the user to crop or rotate the visual, after the upload.  
+The argument `$transformKeepOriginal` overrides the following config which is `true` by default.
+```php
+// config/sharp.php
+
+"uploads" => [
+    'transform_keep_original_image' => true,
+]
+```
 With `$transformKeepOriginal` set to true, the original file will remain unchanged, meaning the transformations will be
 stored apart: using the [built-in way to handle uploads](../sharp-uploads.md), it's transparent. Otherwise, see the
 Formatter part below.

--- a/src/Form/Fields/SharpFormEditorField.php
+++ b/src/Form/Fields/SharpFormEditorField.php
@@ -160,7 +160,7 @@ class SharpFormEditorField extends SharpFormField
         if ($this->cropRatio) {
             $uploadConfig['ratioX'] = (int) $this->cropRatio[0];
             $uploadConfig['ratioY'] = (int) $this->cropRatio[1];
-            $uploadConfig['transformKeepOriginal'] = $this->transformKeepOriginal;
+            $uploadConfig['transformKeepOriginal'] = $this->transformKeepOriginal();
             $uploadConfig['transformableFileTypes'] = $this->transformableFileTypes;
         }
 

--- a/src/Form/Fields/SharpFormUploadField.php
+++ b/src/Form/Fields/SharpFormUploadField.php
@@ -39,7 +39,7 @@ class SharpFormUploadField extends SharpFormField
             'ratioY' => $this->cropRatio ? (int) $this->cropRatio[1] : null,
             'transformable' => $this->transformable,
             'transformableFileTypes' => $this->transformableFileTypes,
-            'transformKeepOriginal' => $this->transformKeepOriginal,
+            'transformKeepOriginal' => $this->transformKeepOriginal(),
             'compactThumbnail' => (bool) $this->compactThumbnail,
             'shouldOptimizeImage' => (bool) $this->shouldOptimizeImage,
         ]);

--- a/src/Form/Fields/Utils/SharpFormFieldWithUpload.php
+++ b/src/Form/Fields/Utils/SharpFormFieldWithUpload.php
@@ -86,7 +86,7 @@ trait SharpFormFieldWithUpload
         return $this->transformable && ! $this->transformKeepOriginal();
     }
 
-    public function transformKeepOriginal(): bool
+    protected function transformKeepOriginal(): bool
     {
         return $this->transformKeepOriginal ?? config('sharp.uploads.transform_keep_original_image', true);
     }

--- a/src/Form/Fields/Utils/SharpFormFieldWithUpload.php
+++ b/src/Form/Fields/Utils/SharpFormFieldWithUpload.php
@@ -12,7 +12,7 @@ trait SharpFormFieldWithUpload
     protected string $storageDisk = 'local';
     protected string|Closure $storageBasePath = 'data';
     protected bool $transformable = true;
-    protected bool $transformKeepOriginal = true;
+    protected ?bool $transformKeepOriginal = null;
     protected bool $compactThumbnail = false;
     protected bool $shouldOptimizeImage = false;
     protected string|array|null $fileFilter = null;
@@ -70,10 +70,11 @@ trait SharpFormFieldWithUpload
         return $this->setTransformable($croppable);
     }
 
-    public function setTransformable(bool $transformable = true, bool $transformKeepOriginal = true): self
+    public function setTransformable(bool $transformable = true, ?bool $transformKeepOriginal = null): self
     {
         $this->transformable = $transformable;
-        if ($transformable) {
+
+        if ($transformable && ! is_null($transformKeepOriginal)) {
             $this->transformKeepOriginal = $transformKeepOriginal;
         }
 
@@ -82,7 +83,12 @@ trait SharpFormFieldWithUpload
 
     public function isTransformOriginal(): bool
     {
-        return $this->transformable && ! $this->transformKeepOriginal;
+        return $this->transformable && ! $this->transformKeepOriginal();
+    }
+
+    public function transformKeepOriginal(): bool
+    {
+        return $this->transformKeepOriginal ?? config('sharp.uploads.transform_keep_original_image', true);
     }
 
     public function setStorageDisk(string $storageDisk): self

--- a/tests/Unit/Form/Fields/SharpFormUploadFieldTest.php
+++ b/tests/Unit/Form/Fields/SharpFormUploadFieldTest.php
@@ -75,6 +75,22 @@ class SharpFormUploadFieldTest extends SharpTestCase
             $formField->toArray(),
         );
     }
+    
+    /** @test */
+    public function we_can_define_transformKeepOriginal_with_config()
+    {
+        config()->set('sharp.uploads.transform_keep_original_image', false);
+
+        $formField = SharpFormUploadField::make('file');
+
+        $this->assertArraySubset(
+            [
+                'transformable' => true,
+                'transformKeepOriginal' => false,
+            ],
+            $formField->toArray(),
+        );
+    }
 
     /** @test */
     public function we_can_define_fileFilter()

--- a/tests/Unit/Form/Fields/SharpFormUploadFieldTest.php
+++ b/tests/Unit/Form/Fields/SharpFormUploadFieldTest.php
@@ -75,7 +75,7 @@ class SharpFormUploadFieldTest extends SharpTestCase
             $formField->toArray(),
         );
     }
-    
+
     /** @test */
     public function we_can_define_transformKeepOriginal_with_config()
     {


### PR DESCRIPTION
Adds `sharp.uploads.transform_keep_original_image` config which can be set to `false` when you don't want to keep the original image after transformation in all upload/editor fields.

closes https://github.com/code16/sharp-dev/issues/250