### PR TITLE
Merge EL fields and layout building in on method

### DIFF
--- a/demo/app/Sharp/Authors/AuthorList.php
+++ b/demo/app/Sharp/Authors/AuthorList.php
@@ -7,7 +7,6 @@ use App\Sharp\Authors\Commands\InviteUserCommand;
 use App\Sharp\Authors\Commands\VisitFacebookProfileCommand;
 use Code16\Sharp\EntityList\Fields\EntityListField;
 use Code16\Sharp\EntityList\Fields\EntityListFieldsContainer;
-use Code16\Sharp\EntityList\Fields\EntityListFieldsLayout;
 use Code16\Sharp\EntityList\SharpEntityList;
 use Code16\Sharp\Utils\Transformers\Attributes\Eloquent\SharpUploadModelThumbnailUrlTransformer;
 use Illuminate\Contracts\Support\Arrayable;
@@ -20,39 +19,30 @@ class AuthorList extends SharpEntityList
         $fieldsContainer
             ->addField(
                 EntityListField::make('avatar')
+                    ->setWidth(1)
+                    ->setWidthOnSmallScreens(2)
                     ->setLabel(''),
             )
             ->addField(
                 EntityListField::make('name')
+                    ->setWidth(3)
+                    ->setWidthOnSmallScreens(5)
                     ->setLabel('Name')
                     ->setSortable(),
             )
             ->addField(
                 EntityListField::make('email')
+                    ->setWidth(4)
+                    ->hideOnSmallScreens()
                     ->setLabel('Email')
                     ->setSortable(),
             )
             ->addField(
                 EntityListField::make('role')
+                    ->setWidth(4)
+                    ->setWidthOnSmallScreens(5)
                     ->setLabel('Role'),
             );
-    }
-
-    protected function buildListLayout(EntityListFieldsLayout $fieldsLayout): void
-    {
-        $fieldsLayout
-            ->addColumn('avatar', 1)
-            ->addColumn('name', 3)
-            ->addColumn('email', 4)
-            ->addColumn('role', 4);
-    }
-
-    protected function buildListLayoutForSmallScreens(EntityListFieldsLayout $fieldsLayout): void
-    {
-        $fieldsLayout
-            ->addColumn('avatar', 2)
-            ->addColumn('name', 5)
-            ->addColumn('role', 5);
     }
 
     public function buildListConfig(): void

--- a/demo/app/Sharp/Categories/CategoryList.php
+++ b/demo/app/Sharp/Categories/CategoryList.php
@@ -6,16 +6,15 @@ use App\Models\Category;
 use App\Sharp\Categories\Commands\CleanUnusedCategoriesCommand;
 use Code16\Sharp\EntityList\Fields\EntityListField;
 use Code16\Sharp\EntityList\Fields\EntityListFieldsContainer;
-use Code16\Sharp\EntityList\Fields\EntityListFieldsLayout;
 use Code16\Sharp\EntityList\SharpEntityList;
 use Code16\Sharp\Utils\Filters\CheckFilter;
 use Illuminate\Contracts\Support\Arrayable;
 
 class CategoryList extends SharpEntityList
 {
-    protected function buildListFields(EntityListFieldsContainer $fieldsContainer): void
+    protected function buildList(EntityListFieldsContainer $fields): void
     {
-        $fieldsContainer
+        $fields
             ->addField(
                 EntityListField::make('name')
                     ->setLabel('Name')
@@ -26,13 +25,6 @@ class CategoryList extends SharpEntityList
                     ->setLabel('# posts')
                     ->setSortable(),
             );
-    }
-
-    protected function buildListLayout(EntityListFieldsLayout $fieldsLayout): void
-    {
-        $fieldsLayout
-            ->addColumn('name', 7)
-            ->addColumn('posts_count', 5);
     }
 
     public function buildListConfig(): void

--- a/demo/app/Sharp/Categories/CategoryList.php
+++ b/demo/app/Sharp/Categories/CategoryList.php
@@ -13,6 +13,28 @@ use Illuminate\Contracts\Support\Arrayable;
 
 class CategoryList extends SharpEntityList
 {
+    protected function buildListFields(EntityListFieldsContainer $fieldsContainer): void
+    {
+        $fieldsContainer
+            ->addField(
+                EntityListField::make('name')
+                    ->setLabel('Name')
+                    ->setSortable(),
+            )
+            ->addField(
+                EntityListField::make('posts_count')
+                    ->setLabel('# posts')
+                    ->setSortable(),
+            );
+    }
+
+    protected function buildListLayout(EntityListFieldsLayout $fieldsLayout): void
+    {
+        $fieldsLayout
+            ->addColumn('name', 7)
+            ->addColumn('posts_count', 5);
+    }
+
     public function buildListConfig(): void
     {
         $this->configureDefaultSort('posts_count', 'desc');
@@ -55,27 +77,5 @@ class CategoryList extends SharpEntityList
             );
 
         return $this->transform($categories->get());
-    }
-
-    protected function buildListFields(EntityListFieldsContainer $fieldsContainer): void
-    {
-        $fieldsContainer
-            ->addField(
-                EntityListField::make('name')
-                    ->setLabel('Name')
-                    ->setSortable(),
-            )
-            ->addField(
-                EntityListField::make('posts_count')
-                    ->setLabel('# posts')
-                    ->setSortable(),
-            );
-    }
-
-    protected function buildListLayout(EntityListFieldsLayout $fieldsLayout): void
-    {
-        $fieldsLayout
-            ->addColumn('name', 7)
-            ->addColumn('posts_count', 5);
     }
 }

--- a/demo/app/Sharp/Posts/Blocks/PostBlockList.php
+++ b/demo/app/Sharp/Posts/Blocks/PostBlockList.php
@@ -14,6 +14,20 @@ use Illuminate\Support\Str;
 
 class PostBlockList extends SharpEntityList
 {
+    protected function buildListFields(EntityListFieldsContainer $fieldsContainer): void
+    {
+        $fieldsContainer
+            ->addField(EntityListField::make('type_label')->setLabel('Type'))
+            ->addField(EntityListField::make('content'));
+    }
+
+    protected function buildListLayout(EntityListFieldsLayout $fieldsLayout): void
+    {
+        $fieldsLayout
+            ->addColumn('type_label', 2)
+            ->addColumn('content');
+    }
+
     public function buildListConfig(): void
     {
         $this->configureMultiformAttribute('type')
@@ -57,19 +71,5 @@ class PostBlockList extends SharpEntityList
                 };
             })
             ->transform($postBlocks);
-    }
-
-    protected function buildListFields(EntityListFieldsContainer $fieldsContainer): void
-    {
-        $fieldsContainer
-            ->addField(EntityListField::make('type_label')->setLabel('Type'))
-            ->addField(EntityListField::make('content'));
-    }
-
-    protected function buildListLayout(EntityListFieldsLayout $fieldsLayout): void
-    {
-        $fieldsLayout
-            ->addColumn('type_label', 2)
-            ->addColumn('content');
     }
 }

--- a/demo/app/Sharp/Posts/PostList.php
+++ b/demo/app/Sharp/Posts/PostList.php
@@ -13,7 +13,6 @@ use App\Sharp\Utils\Filters\PeriodFilter;
 use App\Sharp\Utils\Filters\StateFilter;
 use Code16\Sharp\EntityList\Fields\EntityListField;
 use Code16\Sharp\EntityList\Fields\EntityListFieldsContainer;
-use Code16\Sharp\EntityList\Fields\EntityListFieldsLayout;
 use Code16\Sharp\EntityList\SharpEntityList;
 use Code16\Sharp\Utils\Links\LinkToEntityList;
 use Code16\Sharp\Utils\Transformers\Attributes\Eloquent\SharpUploadModelThumbnailUrlTransformer;
@@ -22,42 +21,34 @@ use Illuminate\Database\Eloquent\Builder;
 
 class PostList extends SharpEntityList
 {
-    protected function buildListFields(EntityListFieldsContainer $fieldsContainer): void
+    protected function buildList(EntityListFieldsContainer $fields): void
     {
-        $fieldsContainer
+        $fields
             ->addField(
-                EntityListField::make('cover'),
+                EntityListField::make('cover')
+                    ->setWidth(1)
+                    ->hideOnSmallScreens(),
             )
             ->addField(
                 EntityListField::make('title')
-                    ->setLabel('Title'),
+                    ->setLabel('Title')
+                    ->setWidth(4)
+                    ->setWidthOnSmallScreens(6),
             )
             ->addField(
                 EntityListField::make('author:name')
                     ->setLabel('Author')
+                    ->setWidth(3)
+                    ->hideOnSmallScreens()
                     ->setSortable(),
             )
             ->addField(
                 EntityListField::make('published_at')
                     ->setLabel('Published at')
+                    ->setWidth(4)
+                    ->setWidthOnSmallScreens(6)
                     ->setSortable(),
             );
-    }
-
-    protected function buildListLayout(EntityListFieldsLayout $fieldsLayout): void
-    {
-        $fieldsLayout
-            ->addColumn('cover', 1)
-            ->addColumn('title', 4)
-            ->addColumn('author:name', 3)
-            ->addColumn('published_at', 4);
-    }
-
-    protected function buildListLayoutForSmallScreens(EntityListFieldsLayout $fieldsLayout): void
-    {
-        $fieldsLayout
-            ->addColumn('title', 6)
-            ->addColumn('published_at', 6);
     }
 
     public function buildListConfig(): void

--- a/docs/guide/building-entity-list.md
+++ b/docs/guide/building-entity-list.md
@@ -14,17 +14,15 @@ php artisan sharp:make:entity-list <class_name> [--model=<model_name>]
 
 ## Write the class
 
-First let's write the applicative class, and make it extend `Code16\Sharp\EntityList\SharpEntityList`. Therefore, there are four abstract methods to implement:
+First let's write the applicative class, and make it extend `Code16\Sharp\EntityList\SharpEntityList`. Therefore, there are two methods to implement:
 
-- `buildListFields(EntityListFieldsContainer $fieldsContainer)` and `buildListLayout(EntityListFieldsLayout $fieldsLayout)` for the structure,
+- `buildList(EntityListFieldsContainer $fields)` for the structure,
 
-- `getListData()` for the data,
+- and `getListData()` for the actual data of the list.
 
-- and `buildListConfig()` for... the list config.
+There are a third optional method, for the list config. Each one is detailed here:
 
-Each one is detailed here:
-
-### `buildListFields(EntityListFieldsContainer $fieldsContainer)`
+### `buildListFields(EntityListFieldsContainer $fields)`
 
 A field is a column in the `Entity List`. This first function is responsible to describe each column:
 
@@ -36,6 +34,8 @@ function buildListFields(EntityListFieldsContainer $fieldsContainer)
             EntityListField::make("name")
                 ->setLabel("Full name")
                 ->setSortable()
+                ->setWidth(6)
+                ->setWidthOnSmallScreens(8)
                 ->setHtml()
         )
         ->addField([...]);
@@ -44,38 +44,8 @@ function buildListFields(EntityListFieldsContainer $fieldsContainer)
 
 Setting the label, allowing the column to be sortable and to display html is optional.
 
-### `buildListLayout(EntityListFieldsLayout $fieldsLayout)`
-
-Next step, define how those columns are displayed:
-
-```php
-function buildListLayout(EntityListFieldsLayout $fieldsLayout)
-{
-    $fieldsLayout->addColumn("picture", 1)
-        ->addColumn("name")
-        ->addColumnLarge("capacity", 2);
-}
-```
-
-We add columns giving:
-
-- the column key, which must match those defined in `buildListFields()`,
-
-- and the "width" of the column, as an integer on a 12-based grid. If missing, it will be deduced.
-
-In this example, `picture` and `capacity` will be displayed respectively on 1/12 and 2/12 of the viewport width. The column `name` will fill the rest, 9/12.
-
-To handle small screens, you can declare an optional `buildListLayoutForSmallScreens(EntityListFieldsLayout $fieldsLayout)` function: 
-
-```php
-function buildListLayoutForSmallScreens(EntityListFieldsLayout $fieldsLayout)
-{
-    $fieldsLayout->addColumn("picture", 4)
-        ->addColumn("name");
-}
-```
-
-With this configuration, `picture` and `name` will have a width of 4/12 and 8/12 (respectively). The third column, `capacity`, will be hidden.
+The `->setWidth(int)` method accepts an integer on a 12-based grid, and is optional too: if missing, it will be deduced (you can use `->setWidthFill()` to force this last behavior).
+You can also call `->widthOnSmallScreens(int)` or `->widthOnSmallScreensFill)` to define a custom width value for small screens. To hide the column on small screens, use `->hideOnSmallScreens()`.
 
 ### `getListData()`
 

--- a/src/EntityList/Fields/EntityListField.php
+++ b/src/EntityList/Fields/EntityListField.php
@@ -44,10 +44,10 @@ class EntityListField
     public function setWidth(int $width = null, int|bool|null $widthOnSmallScreens = null): self
     {
         $this->width = $width;
-        if($widthOnSmallScreens === false) {
+        if ($widthOnSmallScreens === false) {
             $this->widthXs = null;
             $this->hideOnXs = true;
-        } elseif($widthOnSmallScreens !== null) {
+        } elseif ($widthOnSmallScreens !== null) {
             $this->widthXs = $widthOnSmallScreens;
         }
 

--- a/src/EntityList/Fields/EntityListField.php
+++ b/src/EntityList/Fields/EntityListField.php
@@ -8,8 +8,8 @@ class EntityListField
     protected string $label = '';
     protected bool $sortable = false;
     protected bool $html = true;
-    protected ?int $width = null;
-    protected ?int $widthXs = null;
+    protected ?int $width;
+    protected int|bool|null $widthXs;
     protected bool $hideOnXs = false;
 
     public static function make(string $key): self
@@ -41,22 +41,30 @@ class EntityListField
         return $this;
     }
 
-    public function setWidth(int $width = null, int|bool|null $widthOnSmallScreens = null): self
+    public function setWidth(int $width): self
     {
         $this->width = $width;
-        if($widthOnSmallScreens === false) {
-            $this->widthXs = null;
-            $this->hideOnXs = true;
-        } elseif($widthOnSmallScreens !== null) {
-            $this->widthXs = $widthOnSmallScreens;
-        }
 
         return $this;
     }
 
-    public function setWidthOnSmallScreens(int $widthOnSmallScreens = null): self
+    public function setWidthFill(): self
+    {
+        $this->width = null;
+
+        return $this;
+    }
+
+    public function setWidthOnSmallScreens(int $widthOnSmallScreens): self
     {
         $this->widthXs = $widthOnSmallScreens;
+
+        return $this;
+    }
+
+    public function setWidthOnSmallScreensFill(): self
+    {
+        $this->widthXs = true;
 
         return $this;
     }
@@ -82,9 +90,11 @@ class EntityListField
     {
         return [
             'key' => $this->key,
-            'size' => $this->width ?: 'fill',
+            'size' => $this->width ?? 'fill',
             'hideOnXS' => $this->hideOnXs,
-            'sizeXS' => $this->widthXs ?: 'fill',
+            'sizeXS' => isset($this->widthXs)
+                ? ($this->widthXs === true ? 'fill' : $this->widthXs)
+                : ($this->width ?? 'fill'),
         ];
     }
 }

--- a/src/EntityList/Fields/EntityListField.php
+++ b/src/EntityList/Fields/EntityListField.php
@@ -4,12 +4,15 @@ namespace Code16\Sharp\EntityList\Fields;
 
 class EntityListField
 {
-    protected string $key;
+    public string $key;
     protected string $label = '';
     protected bool $sortable = false;
     protected bool $html = true;
+    protected ?int $width = null;
+    protected ?int $widthXs = null;
+    protected bool $hideOnXs = false;
 
-    public static function make(string $key)
+    public static function make(string $key): self
     {
         $instance = new static();
         $instance->key = $key;
@@ -38,13 +41,50 @@ class EntityListField
         return $this;
     }
 
-    public function toArray(): array
+    public function setWidth(int $width = null, int|bool|null $widthOnSmallScreens = null): self
+    {
+        $this->width = $width;
+        if($widthOnSmallScreens === false) {
+            $this->widthXs = null;
+            $this->hideOnXs = true;
+        } elseif($widthOnSmallScreens !== null) {
+            $this->widthXs = $widthOnSmallScreens;
+        }
+
+        return $this;
+    }
+
+    public function setWidthOnSmallScreens(int $widthOnSmallScreens = null): self
+    {
+        $this->widthXs = $widthOnSmallScreens;
+
+        return $this;
+    }
+
+    public function hideOnSmallScreens(bool $hideOnSmallScreens = true): self
+    {
+        $this->hideOnXs = $hideOnSmallScreens;
+
+        return $this;
+    }
+
+    public function getFieldProperties(): array
     {
         return [
             'key' => $this->key,
             'label' => $this->label,
             'sortable' => $this->sortable,
             'html' => $this->html,
+        ];
+    }
+
+    public function getLayoutProperties(): array
+    {
+        return [
+            'key' => $this->key,
+            'size' => $this->width ?: 'fill',
+            'hideOnXS' => $this->hideOnXs,
+            'sizeXS' => $this->widthXs ?: 'fill',
         ];
     }
 }

--- a/src/EntityList/Fields/EntityListFieldsContainer.php
+++ b/src/EntityList/Fields/EntityListFieldsContainer.php
@@ -17,22 +17,22 @@ class EntityListFieldsContainer
 
     public function setWidthOfField(string $fieldKey, ?int $width, int|bool|null $widthOnSmallScreens): self
     {
-        if($width !== null && ($field = collect($this->fields)->firstWhere('key', $fieldKey))) {
-            if($width) {
+        if ($width !== null && ($field = collect($this->fields)->firstWhere('key', $fieldKey))) {
+            if ($width) {
                 $field->setWidth($width);
             } else {
                 $field->setWidthFill();
             }
-            
-            if($widthOnSmallScreens === false) {
+
+            if ($widthOnSmallScreens === false) {
                 $field->hideOnSmallScreens();
-            } elseif($widthOnSmallScreens !== null) {
+            } elseif ($widthOnSmallScreens !== null) {
                 $field->setWidthOnSmallScreens($widthOnSmallScreens);
             } else {
                 $field->setWidthOnSmallScreensFill();
             }
         }
-        
+
         return $this;
     }
 

--- a/src/EntityList/Fields/EntityListFieldsContainer.php
+++ b/src/EntityList/Fields/EntityListFieldsContainer.php
@@ -17,12 +17,20 @@ class EntityListFieldsContainer
 
     public function setWidthOfField(string $fieldKey, ?int $width, int|bool|null $widthOnSmallScreens): self
     {
-        if($field = collect($this->fields)->firstWhere('key', $fieldKey)) {
-            $field->setWidth($width, $widthOnSmallScreens);
-//            if($widthOnSmallScreens === null) {
-//                $field->setWidthOnSmallScreens();
-//            }
-//            $field->setWidthOnSmallScreens($widthOnSmallScreens);
+        if($width !== null && ($field = collect($this->fields)->firstWhere('key', $fieldKey))) {
+            if($width) {
+                $field->setWidth($width);
+            } else {
+                $field->setWidthFill();
+            }
+            
+            if($widthOnSmallScreens === false) {
+                $field->hideOnSmallScreens();
+            } elseif($widthOnSmallScreens !== null) {
+                $field->setWidthOnSmallScreens($widthOnSmallScreens);
+            } else {
+                $field->setWidthOnSmallScreensFill();
+            }
         }
         
         return $this;

--- a/src/EntityList/Fields/EntityListFieldsContainer.php
+++ b/src/EntityList/Fields/EntityListFieldsContainer.php
@@ -15,10 +15,30 @@ class EntityListFieldsContainer
         return $this;
     }
 
+    public function setWidthOfField(string $fieldKey, ?int $width, int|bool|null $widthOnSmallScreens): self
+    {
+        if($field = collect($this->fields)->firstWhere('key', $fieldKey)) {
+            $field->setWidth($width, $widthOnSmallScreens);
+//            if($widthOnSmallScreens === null) {
+//                $field->setWidthOnSmallScreens();
+//            }
+//            $field->setWidthOnSmallScreens($widthOnSmallScreens);
+        }
+        
+        return $this;
+    }
+
     final public function getFields(): Collection
     {
         return collect($this->fields)
-            ->map->toArray()
+            ->map(fn (EntityListField $field) => $field->getFieldProperties())
             ->keyBy('key');
+    }
+
+    final public function getLayout(): Collection
+    {
+        return collect($this->fields)
+            ->map(fn (EntityListField $field) => $field->getLayoutProperties())
+            ->values();
     }
 }

--- a/src/EntityList/Fields/EntityListFieldsContainer.php
+++ b/src/EntityList/Fields/EntityListFieldsContainer.php
@@ -17,14 +17,14 @@ class EntityListFieldsContainer
 
     public function setWidthOfField(string $fieldKey, ?int $width, int|bool|null $widthOnSmallScreens): self
     {
-        if($field = collect($this->fields)->firstWhere('key', $fieldKey)) {
+        if ($field = collect($this->fields)->firstWhere('key', $fieldKey)) {
             $field->setWidth($width, $widthOnSmallScreens);
 //            if($widthOnSmallScreens === null) {
 //                $field->setWidthOnSmallScreens();
 //            }
 //            $field->setWidthOnSmallScreens($widthOnSmallScreens);
         }
-        
+
         return $this;
     }
 

--- a/src/EntityList/Fields/EntityListFieldsLayout.php
+++ b/src/EntityList/Fields/EntityListFieldsLayout.php
@@ -4,6 +4,9 @@ namespace Code16\Sharp\EntityList\Fields;
 
 use Illuminate\Support\Collection;
 
+/**
+ * @deprecated this class will be removed in next major version
+ */
 class EntityListFieldsLayout
 {
     protected array $columns = [];

--- a/src/EntityList/SharpEntityList.php
+++ b/src/EntityList/SharpEntityList.php
@@ -260,7 +260,7 @@ abstract class SharpEntityList
     abstract public function getListData(): array|Arrayable;
 
     /**
-     * Build list fields and layout
+     * Build list fields and layout.
      */
     protected function buildList(EntityListFieldsContainer $fields): void
     {
@@ -273,24 +273,24 @@ abstract class SharpEntityList
         $this->buildListLayout($fieldsLayout);
         $xsFieldsLayout = new EntityListFieldsLayout();
         $this->buildListLayoutForSmallScreens($xsFieldsLayout);
-        
+
         $this->fieldsContainer
             ->getFields()
             ->pluck('key')
             ->each(function ($key) use ($fieldsLayout, $xsFieldsLayout) {
-                if(isset($fieldsLayout->getColumns()[$key])) {
+                if (isset($fieldsLayout->getColumns()[$key])) {
                     $width = $fieldsLayout->getColumns()[$key];
-                    $widthXs = $xsFieldsLayout->hasColumns() 
+                    $widthXs = $xsFieldsLayout->hasColumns()
                         ? $xsFieldsLayout->getColumns()[$key] ?? null
                         : $width;
                     $this->fieldsContainer
                         ->setWidthOfField(
                             $key,
-                            match($width) {
+                            match ($width) {
                                 'fill' => null,
                                 default => $width,
                             },
-                            match($widthXs) {
+                            match ($widthXs) {
                                 'fill' => null,
                                 null => false,
                                 default => $widthXs,
@@ -302,6 +302,7 @@ abstract class SharpEntityList
 
     /**
      * Build list fields.
+     *
      * @deprecated use buildList instead
      */
     protected function buildListFields(EntityListFieldsContainer $fieldsContainer): void
@@ -310,6 +311,7 @@ abstract class SharpEntityList
 
     /**
      * Build list layout.
+     *
      * @deprecated use buildList instead
      */
     protected function buildListLayout(EntityListFieldsLayout $fieldsLayout): void
@@ -318,6 +320,7 @@ abstract class SharpEntityList
 
     /**
      * Build layout for small screen. Optional, only if needed.
+     *
      * @deprecated use buildList instead
      */
     protected function buildListLayoutForSmallScreens(EntityListFieldsLayout $fieldsLayout): void

--- a/src/EntityList/SharpEntityList.php
+++ b/src/EntityList/SharpEntityList.php
@@ -68,17 +68,8 @@ abstract class SharpEntityList
     {
         $this->checkListIsBuilt();
 
-        return $this->fieldsLayout->getColumns()
-            ->keys()
-            ->map(function ($key) {
-                return [
-                    'key' => $key,
-                    'size' => $this->fieldsLayout->getSizeOf($key),
-                    'hideOnXS' => $this->xsFieldsLayout->hasColumns() && $this->xsFieldsLayout->getSizeOf($key) === null,
-                    'sizeXS' => $this->xsFieldsLayout->getSizeOf($key) ?: $this->fieldsLayout->getSizeOf($key),
-                ];
-            })
-            ->values()
+        return $this->fieldsContainer
+            ->getLayout()
             ->toArray();
     }
 
@@ -220,13 +211,7 @@ abstract class SharpEntityList
     {
         if ($this->fieldsContainer === null) {
             $this->fieldsContainer = new EntityListFieldsContainer();
-            $this->buildListFields($this->fieldsContainer);
-
-            $this->fieldsLayout = new EntityListFieldsLayout();
-            $this->buildListLayout($this->fieldsLayout);
-
-            $this->xsFieldsLayout = new EntityListFieldsLayout();
-            $this->buildListLayoutForSmallScreens($this->xsFieldsLayout);
+            $this->buildList($this->fieldsContainer);
         }
     }
 
@@ -275,17 +260,65 @@ abstract class SharpEntityList
     abstract public function getListData(): array|Arrayable;
 
     /**
-     * Build list fields.
+     * Build list fields and layout
      */
-    abstract protected function buildListFields(EntityListFieldsContainer $fieldsContainer): void;
+    protected function buildList(EntityListFieldsContainer $fields): void
+    {
+        // This default implementation is there to avoid breaking changes;
+        // it will be removed in the next major version of Sharp.
+        $this->fieldsContainer = new EntityListFieldsContainer();
+        $this->buildListFields($this->fieldsContainer);
+
+        $fieldsLayout = new EntityListFieldsLayout();
+        $this->buildListLayout($fieldsLayout);
+        $xsFieldsLayout = new EntityListFieldsLayout();
+        $this->buildListLayoutForSmallScreens($xsFieldsLayout);
+        
+        $this->fieldsContainer
+            ->getFields()
+            ->pluck('key')
+            ->each(function ($key) use ($fieldsLayout, $xsFieldsLayout) {
+                if(isset($fieldsLayout->getColumns()[$key])) {
+                    $width = $fieldsLayout->getColumns()[$key];
+                    $widthXs = $xsFieldsLayout->hasColumns() 
+                        ? $xsFieldsLayout->getColumns()[$key] ?? null
+                        : $width;
+                    $this->fieldsContainer
+                        ->setWidthOfField(
+                            $key,
+                            match($width) {
+                                'fill' => null,
+                                default => $width,
+                            },
+                            match($widthXs) {
+                                'fill' => null,
+                                null => false,
+                                default => $widthXs,
+                            },
+                        );
+                }
+            });
+    }
+
+    /**
+     * Build list fields.
+     * @deprecated use buildList instead
+     */
+    protected function buildListFields(EntityListFieldsContainer $fieldsContainer): void
+    {
+    }
 
     /**
      * Build list layout.
+     * @deprecated use buildList instead
      */
-    abstract protected function buildListLayout(EntityListFieldsLayout $fieldsLayout): void;
+    protected function buildListLayout(EntityListFieldsLayout $fieldsLayout): void
+    {
+    }
 
     /**
      * Build layout for small screen. Optional, only if needed.
+     * @deprecated use buildList instead
      */
     protected function buildListLayoutForSmallScreens(EntityListFieldsLayout $fieldsLayout): void
     {
@@ -294,5 +327,7 @@ abstract class SharpEntityList
     /**
      * Build list config.
      */
-    abstract public function buildListConfig(): void;
+    public function buildListConfig(): void
+    {
+    }
 }

--- a/tests/Feature/Api/EntityListControllerTest.php
+++ b/tests/Feature/Api/EntityListControllerTest.php
@@ -96,8 +96,8 @@ class EntityListControllerTest extends BaseApiTest
     /** @test */
     public function we_can_get_list_layout_for_an_entity()
     {
-        $this->json('get', '/sharp/api/list/person')
-            ->assertStatus(200)
+        $this->getJson('/sharp/api/list/person')
+            ->assertOk()
             ->assertJson(['layout' => [
                 [
                     'key' => 'name',
@@ -107,7 +107,7 @@ class EntityListControllerTest extends BaseApiTest
                 ], [
                     'key' => 'age',
                     'size' => 6,
-                    'sizeXS' => 6,
+                    'sizeXS' => 'fill',
                     'hideOnXS' => true,
                 ],
             ]]);

--- a/tests/Feature/Api/EntityListControllerTest.php
+++ b/tests/Feature/Api/EntityListControllerTest.php
@@ -107,7 +107,7 @@ class EntityListControllerTest extends BaseApiTest
                 ], [
                     'key' => 'age',
                     'size' => 6,
-                    'sizeXS' => 'fill',
+                    'sizeXS' => 6,
                     'hideOnXS' => true,
                 ],
             ]]);

--- a/tests/Fixtures/PersonSharpEntityList.php
+++ b/tests/Fixtures/PersonSharpEntityList.php
@@ -89,7 +89,7 @@ class PersonSharpEntityList extends SharpEntityList
                     ->setSortable(),
             );
     }
-    
+
     public function getFilters(): ?array
     {
         return [

--- a/tests/Fixtures/PersonSharpEntityList.php
+++ b/tests/Fixtures/PersonSharpEntityList.php
@@ -5,7 +5,6 @@ namespace Code16\Sharp\Tests\Fixtures;
 use Code16\Sharp\EntityList\Commands\ReorderHandler;
 use Code16\Sharp\EntityList\Fields\EntityListField;
 use Code16\Sharp\EntityList\Fields\EntityListFieldsContainer;
-use Code16\Sharp\EntityList\Fields\EntityListFieldsLayout;
 use Code16\Sharp\EntityList\Filters\EntityListSelectFilter;
 use Code16\Sharp\EntityList\Filters\EntityListSelectMultipleFilter;
 use Code16\Sharp\EntityList\Filters\EntityListSelectRequiredFilter;
@@ -78,26 +77,19 @@ class PersonSharpEntityList extends SharpEntityList
                 EntityListField::make('name')
                     ->setLabel('Name')
                     ->setHtml()
+                    ->setWidth(6)
+                    ->setWidthOnSmallScreensFill()
                     ->setSortable(),
             )
             ->addField(
                 EntityListField::make('age')
                     ->setLabel('Age')
+                    ->setWidth(6)
+                    ->hideOnSmallScreens()
                     ->setSortable(),
             );
     }
-
-    public function buildListLayout(EntityListFieldsLayout $fieldsLayout): void
-    {
-        $fieldsLayout->addColumn('name', 6)
-            ->addColumn('age', 6);
-    }
-
-    public function buildListLayoutForSmallScreens(EntityListFieldsLayout $fieldsLayout): void
-    {
-        $fieldsLayout->addColumn('name');
-    }
-
+    
     public function getFilters(): ?array
     {
         return [

--- a/tests/Unit/EntityList/SharpEntityListDeprecatedLayoutTest.php
+++ b/tests/Unit/EntityList/SharpEntityListDeprecatedLayoutTest.php
@@ -1,0 +1,110 @@
+<?php
+
+namespace Code16\Sharp\Tests\Unit\EntityList;
+
+use Code16\Sharp\EntityList\Fields\EntityListField;
+use Code16\Sharp\EntityList\Fields\EntityListFieldsContainer;
+use Code16\Sharp\EntityList\Fields\EntityListFieldsLayout;
+use Code16\Sharp\Tests\SharpTestCase;
+use Code16\Sharp\Tests\Unit\EntityList\Utils\SharpEntityDefaultTestList;
+
+class SharpEntityListDeprecatedLayoutTest extends SharpTestCase
+{
+    /** @test */
+    public function we_can_get_layout_in_the_deprecated_way()
+    {
+        $list = new class extends SharpEntityDefaultTestList
+        {
+            public function buildListFields(EntityListFieldsContainer $fieldsContainer): void
+            {
+                $fieldsContainer
+                    ->addField(EntityListField::make('name'))
+                    ->addField(EntityListField::make('age'));
+            }
+
+            public function buildListLayout(EntityListFieldsLayout $fieldsLayout): void
+            {
+                $fieldsLayout->addColumn('name', 6)
+                    ->addColumn('age', 6);
+            }
+        };
+
+        $this->assertEquals(
+            [
+                [
+                    'key' => 'name', 'size' => 6, 'sizeXS' => 6, 'hideOnXS' => false,
+                ], [
+                    'key' => 'age', 'size' => 6, 'sizeXS' => 6, 'hideOnXS' => false,
+                ],
+            ],
+            $list->listLayout(),
+        );
+    }
+
+    /** @test */
+    public function we_can_define_a_layout_for_small_screens_in_the_deprecated_way()
+    {
+        $list = new class extends SharpEntityDefaultTestList
+        {
+            public function buildListFields(EntityListFieldsContainer $fieldsContainer): void
+            {
+                $fieldsContainer
+                    ->addField(EntityListField::make('name'))
+                    ->addField(EntityListField::make('age'));
+            }
+
+            public function buildListLayout(EntityListFieldsLayout $fieldsLayout): void
+            {
+                $fieldsLayout->addColumn('name', 6)
+                    ->addColumn('age', 6);
+            }
+
+            public function buildListLayoutForSmallScreens(EntityListFieldsLayout $fieldsLayout): void
+            {
+                $fieldsLayout->addColumn('name', 12);
+            }
+        };
+
+        $this->assertEquals(
+            [
+                [
+                    'key' => 'name', 'size' => 6, 'sizeXS' => 12, 'hideOnXS' => false,
+                ], [
+                    'key' => 'age', 'size' => 6, 'sizeXS' => 6, 'hideOnXS' => true,
+                ],
+            ],
+            $list->listLayout(),
+        );
+    }
+
+    /** @test */
+    public function we_can_configure_a_column_to_fill_left_space_in_the_deprecated_way()
+    {
+        $list = new class extends SharpEntityDefaultTestList
+        {
+            public function buildListFields(EntityListFieldsContainer $fieldsContainer): void
+            {
+                $fieldsContainer
+                    ->addField(EntityListField::make('name'))
+                    ->addField(EntityListField::make('age'));
+            }
+
+            public function buildListLayout(EntityListFieldsLayout $fieldsLayout): void
+            {
+                $fieldsLayout->addColumn('name', 4)
+                    ->addColumn('age');
+            }
+        };
+
+        $this->assertEquals(
+            [
+                [
+                    'key' => 'name', 'size' => 4, 'sizeXS' => 4, 'hideOnXS' => false,
+                ], [
+                    'key' => 'age', 'size' => 'fill', 'sizeXS' => 'fill', 'hideOnXS' => false,
+                ],
+            ],
+            $list->listLayout(),
+        );
+    }
+}

--- a/tests/Unit/EntityList/SharpEntityListTest.php
+++ b/tests/Unit/EntityList/SharpEntityListTest.php
@@ -4,7 +4,6 @@ namespace Code16\Sharp\Tests\Unit\EntityList;
 
 use Code16\Sharp\EntityList\Fields\EntityListField;
 use Code16\Sharp\EntityList\Fields\EntityListFieldsContainer;
-use Code16\Sharp\EntityList\Fields\EntityListFieldsLayout;
 use Code16\Sharp\Show\Fields\SharpShowHtmlField;
 use Code16\Sharp\Tests\SharpTestCase;
 use Code16\Sharp\Tests\Unit\EntityList\Utils\SharpEntityDefaultTestList;
@@ -48,24 +47,15 @@ class SharpEntityListTest extends SharpTestCase
             public function buildListFields(EntityListFieldsContainer $fieldsContainer): void
             {
                 $fieldsContainer
-                    ->addField(EntityListField::make('name'))
-                    ->addField(EntityListField::make('age'));
-            }
-
-            public function buildListLayout(EntityListFieldsLayout $fieldsLayout): void
-            {
-                $fieldsLayout->addColumn('name', 6)
-                    ->addColumn('age', 6);
+                    ->addField(EntityListField::make('name')->setWidth(6))
+                    ->addField(EntityListField::make('age')->setWidth(6));
             }
         };
 
         $this->assertEquals(
             [
-                [
-                    'key' => 'name', 'size' => 6, 'sizeXS' => 6, 'hideOnXS' => false,
-                ], [
-                    'key' => 'age', 'size' => 6, 'sizeXS' => 6, 'hideOnXS' => false,
-                ],
+                ['key' => 'name', 'size' => 6, 'sizeXS' => 6, 'hideOnXS' => false], 
+                ['key' => 'age', 'size' => 6, 'sizeXS' => 6, 'hideOnXS' => false],
             ],
             $list->listLayout(),
         );
@@ -79,29 +69,15 @@ class SharpEntityListTest extends SharpTestCase
             public function buildListFields(EntityListFieldsContainer $fieldsContainer): void
             {
                 $fieldsContainer
-                    ->addField(EntityListField::make('name'))
-                    ->addField(EntityListField::make('age'));
-            }
-
-            public function buildListLayout(EntityListFieldsLayout $fieldsLayout): void
-            {
-                $fieldsLayout->addColumn('name', 6)
-                    ->addColumn('age', 6);
-            }
-
-            public function buildListLayoutForSmallScreens(EntityListFieldsLayout $fieldsLayout): void
-            {
-                $fieldsLayout->addColumn('name', 12);
+                    ->addField(EntityListField::make('name')->setWidth(6)->setWidthOnSmallScreens(12))
+                    ->addField(EntityListField::make('age')->setWidth(6)->hideOnSmallScreens());
             }
         };
 
         $this->assertEquals(
             [
-                [
-                    'key' => 'name', 'size' => 6, 'sizeXS' => 12, 'hideOnXS' => false,
-                ], [
-                    'key' => 'age', 'size' => 6, 'sizeXS' => 'fill', 'hideOnXS' => true,
-                ],
+                ['key' => 'name', 'size' => 6, 'sizeXS' => 12, 'hideOnXS' => false], 
+                ['key' => 'age', 'size' => 6, 'sizeXS' => 6, 'hideOnXS' => true],
             ],
             $list->listLayout(),
         );
@@ -115,24 +91,15 @@ class SharpEntityListTest extends SharpTestCase
             public function buildListFields(EntityListFieldsContainer $fieldsContainer): void
             {
                 $fieldsContainer
-                    ->addField(EntityListField::make('name'))
+                    ->addField(EntityListField::make('name')->setWidthOnSmallScreens(4))
                     ->addField(EntityListField::make('age'));
-            }
-
-            public function buildListLayout(EntityListFieldsLayout $fieldsLayout): void
-            {
-                $fieldsLayout->addColumn('name', 4)
-                    ->addColumn('age');
             }
         };
 
         $this->assertEquals(
             [
-                [
-                    'key' => 'name', 'size' => 4, 'sizeXS' => 4, 'hideOnXS' => false,
-                ], [
-                    'key' => 'age', 'size' => 'fill', 'sizeXS' => 'fill', 'hideOnXS' => false,
-                ],
+                ['key' => 'name', 'size' => 'fill', 'sizeXS' => 4, 'hideOnXS' => false], 
+                ['key' => 'age', 'size' => 'fill', 'sizeXS' => 'fill', 'hideOnXS' => false],
             ],
             $list->listLayout(),
         );

--- a/tests/Unit/EntityList/SharpEntityListTest.php
+++ b/tests/Unit/EntityList/SharpEntityListTest.php
@@ -54,7 +54,7 @@ class SharpEntityListTest extends SharpTestCase
 
         $this->assertEquals(
             [
-                ['key' => 'name', 'size' => 6, 'sizeXS' => 6, 'hideOnXS' => false], 
+                ['key' => 'name', 'size' => 6, 'sizeXS' => 6, 'hideOnXS' => false],
                 ['key' => 'age', 'size' => 6, 'sizeXS' => 6, 'hideOnXS' => false],
             ],
             $list->listLayout(),
@@ -76,7 +76,7 @@ class SharpEntityListTest extends SharpTestCase
 
         $this->assertEquals(
             [
-                ['key' => 'name', 'size' => 6, 'sizeXS' => 12, 'hideOnXS' => false], 
+                ['key' => 'name', 'size' => 6, 'sizeXS' => 12, 'hideOnXS' => false],
                 ['key' => 'age', 'size' => 6, 'sizeXS' => 6, 'hideOnXS' => true],
             ],
             $list->listLayout(),
@@ -98,7 +98,7 @@ class SharpEntityListTest extends SharpTestCase
 
         $this->assertEquals(
             [
-                ['key' => 'name', 'size' => 'fill', 'sizeXS' => 4, 'hideOnXS' => false], 
+                ['key' => 'name', 'size' => 'fill', 'sizeXS' => 4, 'hideOnXS' => false],
                 ['key' => 'age', 'size' => 'fill', 'sizeXS' => 'fill', 'hideOnXS' => false],
             ],
             $list->listLayout(),

--- a/tests/Unit/EntityList/SharpEntityListTest.php
+++ b/tests/Unit/EntityList/SharpEntityListTest.php
@@ -100,7 +100,7 @@ class SharpEntityListTest extends SharpTestCase
                 [
                     'key' => 'name', 'size' => 6, 'sizeXS' => 12, 'hideOnXS' => false,
                 ], [
-                    'key' => 'age', 'size' => 6, 'sizeXS' => 6, 'hideOnXS' => true,
+                    'key' => 'age', 'size' => 6, 'sizeXS' => 'fill', 'hideOnXS' => true,
                 ],
             ],
             $list->listLayout(),


### PR DESCRIPTION
With this PR, we can replace this:

```php
class PostList extends SharpEntityList
{
    protected function buildListFields(EntityListFieldsContainer $fieldsContainer): void
    {
        $fieldsContainer
            ->addField(
                EntityListField::make('cover'),
            )
            ->addField(
                EntityListField::make('title')
                    ->setLabel('Title'),
            )
            ->addField(
                EntityListField::make('author:name')
                    ->setLabel('Author')
                    ->setSortable(),
            )
            ->addField(
                EntityListField::make('published_at')
                    ->setLabel('Published at')
                    ->setSortable(),
            );
    }

    protected function buildListLayout(EntityListFieldsLayout $fieldsLayout): void
    {
        $fieldsLayout
            ->addColumn('cover', 1)
            ->addColumn('title', 4)
            ->addColumn('author:name', 3)
            ->addColumn('published_at', 4);
    }

    protected function buildListLayoutForSmallScreens(EntityListFieldsLayout $fieldsLayout): void
    {
        $fieldsLayout
            ->addColumn('title', 6)
            ->addColumn('published_at', 6);
    }
    // ...
}
```


With this:

```php
class PostList extends SharpEntityList
{
    protected function buildList(EntityListFieldsContainer $fields): void
    {
        $fields
            ->addField(
                EntityListField::make('cover')
                    ->setWidth(1)
                    ->hideOnSmallScreens(),
            )
            ->addField(
                EntityListField::make('title')
                    ->setLabel('Title')
                    ->setWidth(4)
                    ->setWidthOnSmallScreens(6),
            )
            ->addField(
                EntityListField::make('author:name')
                    ->setLabel('Author')
                    ->setWidth(3)
                    ->hideOnSmallScreens()
                    ->setSortable(),
            )
            ->addField(
                EntityListField::make('published_at')
                    ->setLabel('Published at')
                    ->setWidth(4)
                    ->setWidthOnSmallScreens(6)
                    ->setSortable(),
            );
    }
    // ...
}
```

I find this is more expressive, more simple and shorter to write.
The old API is still supported to avoid breaking changes.