### PR TITLE
[demo] better 2fa infobox and help text

### DIFF
--- a/demo/app/Sharp/Demo2faNotificationHandler.php
+++ b/demo/app/Sharp/Demo2faNotificationHandler.php
@@ -6,11 +6,6 @@ use Code16\Sharp\Auth\TwoFactor\Sharp2faNotificationHandler;
 
 class Demo2faNotificationHandler extends Sharp2faNotificationHandler
 {
-    public function isEnabledFor($user): bool
-    {
-        return $user->email === 'editor@example.org';
-    }
-
     protected function generateRandomCode(): int
     {
         return 123456;
@@ -19,8 +14,12 @@ class Demo2faNotificationHandler extends Sharp2faNotificationHandler
     public function formHelpText(): string
     {
         return <<<'HTML'
-                <div>This user has configured a two-factor authentication.</div>
-                <div class="mt-2">Code was set to <strong>123456</strong></div>
+                <div class="alert alert-info">
+                    <div>Two-factor authentication based on email notifications has been enabled for all users.</div>
+                    <div class="mt-2">Expected code is <strong>123456</strong>.</div>
+                    <div class="mt-2">It is also possible to set an authentification based on a TOTP authenticator app (like Google or Microsoft Authenticator). Check the <a href="https://sharp.code16.fr/docs/guide/authentication.html#two-factor-authentication" target="_blank">documentation</a>.</div>
+                </div>
+                An email has been sent to your address. Please enter the 6-digit code.
             HTML;
     }
 }

--- a/demo/app/Sharp/Demo2faNotificationHandler.php
+++ b/demo/app/Sharp/Demo2faNotificationHandler.php
@@ -15,11 +15,10 @@ class Demo2faNotificationHandler extends Sharp2faNotificationHandler
     {
         return <<<'HTML'
                 <div class="alert alert-info">
-                    <div>Two-factor authentication based on email notifications has been enabled for all users.</div>
-                    <div class="mt-2">Expected code is <strong>123456</strong>.</div>
-                    <div class="mt-2">It is also possible to set an authentification based on a TOTP authenticator app (like Google or Microsoft Authenticator). Check the <a href="https://sharp.code16.fr/docs/guide/authentication.html#two-factor-authentication" target="_blank">documentation</a>.</div>
+                    <div><a href="https://sharp.code16.fr/docs/guide/authentication.html#two-factor-authentication" target="_blank">Two-factor authentication</a> comes with two flavours: notification (mail, sms, etc) or TOTP authenticator app (like Google Authenticator).</div>
+                    <div class="mt-2">This is a demo, expected code is <strong>123456</strong>.</div>
                 </div>
-                An email has been sent to your address. Please enter the 6-digit code.
+                Please enter the 6-digit code
             HTML;
     }
 }

--- a/demo/app/Sharp/Demo2faNotificationHandler.php
+++ b/demo/app/Sharp/Demo2faNotificationHandler.php
@@ -15,7 +15,7 @@ class Demo2faNotificationHandler extends Sharp2faNotificationHandler
     {
         return <<<'HTML'
                 <div class="alert alert-info">
-                    <div><a href="https://sharp.code16.fr/docs/guide/authentication.html#two-factor-authentication" target="_blank">Two-factor authentication</a> comes with two flavours: notification (mail, sms, etc) or TOTP authenticator app (like Google Authenticator).</div>
+                    <div><a href="https://sharp.code16.fr/docs/guide/authentication.html#two-factor-authentication" target="_blank">Two-factor authentication</a> comes with two flavours: notification (mail, sms, etc) or TOTP app (like Google Authenticator).</div>
                     <div class="mt-2">This is a demo, expected code is <strong>123456</strong>.</div>
                 </div>
                 Please enter the 6-digit code

--- a/resources/lang/back/en/auth.php
+++ b/resources/lang/back/en/auth.php
@@ -6,13 +6,13 @@ return [
     '2fa' => [
         'validation_error' => 'Please enter a value for the code',
         'invalid' => 'This code is invalid',
-        'form_help_text' => 'Please enter the 6 figures of the validation code',
+        'form_help_text' => 'An email has been sent to your address. Please enter the 6-digit code.',
         'notification' => [
             'mail_subject' => 'Your connection code',
             'mail_body' => 'Here is the code to enter to connect:',
         ],
         'totp' => [
-            'form_help_text' => 'Please enter the 6 figures of the validation code, or one of your recovery codes that you have not used previously.',
+            'form_help_text' => 'Please enter the 6-digit from your application, or one of your recovery codes that you have not used previously.',
             'commands' => [
                 'activate' => [
                     'command_label' => 'Configure two-factor authentication',

--- a/resources/lang/back/en/auth.php
+++ b/resources/lang/back/en/auth.php
@@ -6,7 +6,7 @@ return [
     '2fa' => [
         'validation_error' => 'Please enter a value for the code',
         'invalid' => 'This code is invalid',
-        'form_help_text' => 'An email has been sent to your address. Please enter the 6-digit code.',
+        'form_help_text' => 'Please enter the 6-digit code',
         'notification' => [
             'mail_subject' => 'Your connection code',
             'mail_body' => 'Here is the code to enter to connect:',


### PR DESCRIPTION
- enabled 2fa for all users on demo
- better info box to learn about the feature + understand why the expected code is here (it's a demo)
- better default help text (rephrase ~~figures~~ into digits)

### Before

![Screenshot from 2023-12-12 11-49-43](https://github.com/code16/sharp/assets/2412608/e6929d2b-380f-4044-be63-4345c9e01bfe)

help text by default

![Screenshot from 2023-12-12 13-54-18](https://github.com/code16/sharp/assets/2412608/8d844262-445b-480d-b400-3a9dd33f5faa)


### After

![Screenshot from 2023-12-12 18-30-55](https://github.com/code16/sharp/assets/2412608/0037ddfd-f7a7-442d-bdfb-bca8716c620c)



