### PR TITLE
Quickfix empty EL

### DIFF
--- a/demo/app/Providers/AppServiceProvider.php
+++ b/demo/app/Providers/AppServiceProvider.php
@@ -14,7 +14,7 @@ class AppServiceProvider extends ServiceProvider
         $this->app->register(SharpServiceProvider::class);
 //        $this->app->bind(SharpUploadModel::class, Media::class)
 
-        if(class_exists(SharpDevServiceProvider::class)) {
+        if (class_exists(SharpDevServiceProvider::class)) {
             $this->app->register(SharpDevServiceProvider::class);
         }
 

--- a/src/Data/PaginatorMetaData.php
+++ b/src/Data/PaginatorMetaData.php
@@ -10,12 +10,12 @@ final class PaginatorMetaData extends Data
     public function __construct(
         public int $current_page,
         public string $first_page_url,
-        public int $from,
+        public ?int $from,
         public ?string $next_page_url,
         public string $path,
         public int $per_page,
         public ?string $prev_page_url,
-        public int $to,
+        public ?int $to,
         #[LiteralTypeScriptType('Array<{ url: string|null, label: string, active: boolean }>')]
         public ?array $links = null,
         public ?int $last_page = null,


### PR DESCRIPTION
```
message: "Code16\Sharp\Data\PaginatorMetaData::__construct(): Argument #3 ($from) must be of type int, null given, called in /sharp/src/Data/PaginatorMetaData.php on line 32"
        #code: 0
        #file: "./src/Data/PaginatorMetaData.php"
        #line: 10
```
