### PR TITLE
Entity list state field

### DIFF
--- a/demo/app/Sharp/Posts/PostList.php
+++ b/demo/app/Sharp/Posts/PostList.php
@@ -35,8 +35,9 @@ class PostList extends SharpEntityList
                 EntityListField::make('title')
                     ->setLabel('Title')
                     ->setWidth(4)
-                    ->setWidthOnSmallScreens(6),
+                    ->setWidthOnSmallScreensFill(),
             )
+            ->addStateField()
             ->addField(
                 EntityListField::make('author:name')
                     ->setLabel('Author')
@@ -48,7 +49,7 @@ class PostList extends SharpEntityList
                 EntityListField::make('published_at')
                     ->setLabel('Published at')
                     ->setWidth(4)
-                    ->setWidthOnSmallScreens(6)
+                    ->setWidthOnSmallScreensFill()
                     ->setSortable(),
             );
     }
@@ -64,7 +65,7 @@ class PostList extends SharpEntityList
 
     protected function buildPageAlert(PageAlert $pageAlert): void
     {
-        if (! auth()->user()->isAdmin()) {
+        if (!auth()->user()->isAdmin()) {
             $pageAlert
                 ->setMessage('As an editor, you can only edit your posts; you can see other posts except those which are still in draft.')
                 ->setLevelSecondary();
@@ -176,7 +177,7 @@ class PostList extends SharpEntityList
                     $instance->getTranslation('title', 'en'),
                     $instance->categories
                         ->pluck('name')
-                        ->map(fn ($name) => '<span class="badge">'.$name.'</span>')
+                        ->map(fn($name) => '<span class="badge">'.$name.'</span>')
                         ->implode(' '),
                 );
             })

--- a/resources/js/entity-list/components/EntityList.vue
+++ b/resources/js/entity-list/components/EntityList.vue
@@ -414,32 +414,30 @@
                                                 </TableCell>
                                             </template>
                                             <template v-for="(field, fieldIndex) in entityList.fields">
-                                                <template v-if="field.key === '@state'">
-                                                    <template v-if="entityList.config.state && showEntityState">
-                                                        <TableCell class="relative">
-                                                            <DropdownMenu>
-                                                                <DropdownMenuTrigger>
-                                                                    <Button variant="ghost" size="sm">
-                                                                        <Badge variant="outline">
-                                                                            <StateIcon class="-ml-0.5 mr-1.5" :state-value="entityList.instanceStateValue(item)" />
-                                                                            {{ entityList.instanceStateValue(item)?.label }}
-                                                                        </Badge>
-                                                                    </Button>
-                                                                </DropdownMenuTrigger>
-                                                                <DropdownMenuContent align="start" :align-offset="-16">
-                                                                    <template v-for="stateValue in entityList.config.state.values" :key="stateValue.value">
-                                                                        <DropdownMenuCheckboxItem
-                                                                            :checked="stateValue.value == entityList.instanceState(item)"
-                                                                            @update:checked="(checked) => checked && onInstanceStateChange(stateValue.value, entityList.instanceId(item))"
-                                                                        >
-                                                                            <StateIcon class="mr-1.5" :state-value="stateValue" />
-                                                                            <span class="truncate">{{ stateValue.label }}</span>
-                                                                        </DropdownMenuCheckboxItem>
-                                                                    </template>
-                                                                </DropdownMenuContent>
-                                                            </DropdownMenu>
-                                                        </TableCell>
-                                                    </template>
+                                                <template v-if="field.key === '@state' && entityList.config.state && showEntityState">
+                                                    <TableCell>
+                                                        <DropdownMenu>
+                                                            <DropdownMenuTrigger as-child>
+                                                                <Button class="relative" variant="ghost" size="sm">
+                                                                    <Badge variant="outline">
+                                                                        <StateIcon class="-ml-0.5 mr-1.5" :state-value="entityList.instanceStateValue(item)" />
+                                                                        {{ entityList.instanceStateValue(item)?.label }}
+                                                                    </Badge>
+                                                                </Button>
+                                                            </DropdownMenuTrigger>
+                                                            <DropdownMenuContent align="start" :align-offset="-16">
+                                                                <template v-for="stateValue in entityList.config.state.values" :key="stateValue.value">
+                                                                    <DropdownMenuCheckboxItem
+                                                                        :checked="stateValue.value == entityList.instanceState(item)"
+                                                                        @update:checked="(checked) => checked && onInstanceStateChange(stateValue.value, entityList.instanceId(item))"
+                                                                    >
+                                                                        <StateIcon class="mr-1.5" :state-value="stateValue" />
+                                                                        <span class="truncate">{{ stateValue.label }}</span>
+                                                                    </DropdownMenuCheckboxItem>
+                                                                </template>
+                                                            </DropdownMenuContent>
+                                                        </DropdownMenu>
+                                                    </TableCell>
                                                 </template>
                                                 <template v-else>
                                                     <TableCell>

--- a/resources/js/entity-list/components/EntityList.vue
+++ b/resources/js/entity-list/components/EntityList.vue
@@ -414,48 +414,53 @@
                                                 </TableCell>
                                             </template>
                                             <template v-for="(field, fieldIndex) in entityList.fields">
-                                                <TableCell>
-                                                    <template v-if="fieldIndex === 0 && entityList.instanceUrl(item) && !selecting && !reordering">
-                                                        <a class="absolute inset-0" :href="entityList.instanceUrl(item)"></a>
+                                                <template v-if="field.key === '@state'">
+                                                    <template v-if="entityList.config.state && showEntityState">
+                                                        <TableCell class="relative">
+                                                            <DropdownMenu>
+                                                                <DropdownMenuTrigger>
+                                                                    <Button variant="ghost" size="sm">
+                                                                        <Badge variant="outline">
+                                                                            <StateIcon class="-ml-0.5 mr-1.5" :state-value="entityList.instanceStateValue(item)" />
+                                                                            {{ entityList.instanceStateValue(item)?.label }}
+                                                                        </Badge>
+                                                                    </Button>
+                                                                </DropdownMenuTrigger>
+                                                                <DropdownMenuContent align="start" :align-offset="-16">
+                                                                    <template v-for="stateValue in entityList.config.state.values" :key="stateValue.value">
+                                                                        <DropdownMenuCheckboxItem
+                                                                            :checked="stateValue.value == entityList.instanceState(item)"
+                                                                            @update:checked="(checked) => checked && onInstanceStateChange(stateValue.value, entityList.instanceId(item))"
+                                                                        >
+                                                                            <StateIcon class="mr-1.5" :state-value="stateValue" />
+                                                                            <span class="truncate">{{ stateValue.label }}</span>
+                                                                        </DropdownMenuCheckboxItem>
+                                                                    </template>
+                                                                </DropdownMenuContent>
+                                                            </DropdownMenu>
+                                                        </TableCell>
                                                     </template>
-                                                    <template v-if="field.html">
-                                                        <CaptureInternalLinks>
-                                                            <div class="[&_a]:relative [&_a]:underline [&_a]:z-10 [&_a]:text-indigo-600 [&_a:hover]:text-indigo-900"
-                                                                :class="{ '[&_a]:pointer-events-none': selecting || reordering }"
-                                                                v-html="item[field.key]"
-                                                            ></div>
-                                                        </CaptureInternalLinks>
-                                                    </template>
-                                                    <template v-else>
-                                                        {{ item[field.key] }}
-                                                    </template>
-                                                </TableCell>
+                                                </template>
+                                                <template v-else>
+                                                    <TableCell>
+                                                        <template v-if="fieldIndex === 0 && entityList.instanceUrl(item) && !selecting && !reordering">
+                                                            <a class="absolute inset-0" :href="entityList.instanceUrl(item)"></a>
+                                                        </template>
+                                                        <template v-if="field.html">
+                                                            <CaptureInternalLinks>
+                                                                <div class="[&_a]:relative [&_a]:underline [&_a]:z-10 [&_a]:text-indigo-600 [&_a:hover]:text-indigo-900"
+                                                                    :class="{ '[&_a]:pointer-events-none': selecting || reordering }"
+                                                                    v-html="item[field.key]"
+                                                                ></div>
+                                                            </CaptureInternalLinks>
+                                                        </template>
+                                                        <template v-else>
+                                                            {{ item[field.key] }}
+                                                        </template>
+                                                    </TableCell>
+                                                </template>
                                             </template>
-                                            <template v-if="entityList.config.state && showEntityState">
-                                                <TableCell class="relative">
-                                                    <DropdownMenu>
-                                                        <DropdownMenuTrigger>
-                                                            <Button variant="ghost" size="sm">
-                                                                <Badge variant="outline">
-                                                                    <StateIcon class="-ml-0.5 mr-1.5" :state-value="entityList.instanceStateValue(item)" />
-                                                                    {{ entityList.instanceStateValue(item)?.label }}
-                                                                </Badge>
-                                                            </Button>
-                                                        </DropdownMenuTrigger>
-                                                        <DropdownMenuContent align="start" :align-offset="-16">
-                                                            <template v-for="stateValue in entityList.config.state.values" :key="stateValue.value">
-                                                                <DropdownMenuCheckboxItem
-                                                                    :checked="stateValue.value == entityList.instanceState(item)"
-                                                                    @update:checked="(checked) => checked && onInstanceStateChange(stateValue.value, entityList.instanceId(item))"
-                                                                >
-                                                                    <StateIcon class="mr-1.5" :state-value="stateValue" />
-                                                                    <span class="truncate">{{ stateValue.label }}</span>
-                                                                </DropdownMenuCheckboxItem>
-                                                            </template>
-                                                        </DropdownMenuContent>
-                                                    </DropdownMenu>
-                                                </TableCell>
-                                            </template>
+
                                             <template v-if="!reordering && entityList.instanceHasActions(item, showEntityState)">
                                                 <TableCell class="relative">
                                                     <EntityActions v-slot="{ menuOpened, stateSubmenuOpened, requestedStateMenu, openStateMenu }">

--- a/src/EntityList/Fields/EntityListField.php
+++ b/src/EntityList/Fields/EntityListField.php
@@ -2,7 +2,7 @@
 
 namespace Code16\Sharp\EntityList\Fields;
 
-class EntityListField
+class EntityListField implements IsEntityListField
 {
     public string $key;
     protected string $label = '';

--- a/src/EntityList/Fields/EntityListFieldsContainer.php
+++ b/src/EntityList/Fields/EntityListFieldsContainer.php
@@ -46,8 +46,14 @@ class EntityListFieldsContainer
         return $this;
     }
 
-    final public function getFields(): Collection
+    final public function getFields(bool $shouldHaveStateField = false): Collection
     {
+        if($shouldHaveStateField
+            && !collect($this->fields)->whereInstanceOf(EntityListStateField::class)->first()
+        ) {
+            $this->addStateField();
+        }
+        
         return collect($this->fields)
             ->map(fn (IsEntityListField $field) => $field->getFieldProperties());
     }

--- a/src/EntityList/Fields/EntityListFieldsContainer.php
+++ b/src/EntityList/Fields/EntityListFieldsContainer.php
@@ -18,6 +18,13 @@ class EntityListFieldsContainer
         return $this;
     }
 
+    final public function addStateField(?string $label = null): self
+    {
+        $this->fields[] = new EntityListStateField($label ?? '');
+
+        return $this;
+    }
+
     public function setWidthOfField(string $fieldKey, ?int $width, int|bool|null $widthOnSmallScreens): self
     {
         if ($width !== null && ($field = collect($this->fields)->firstWhere('key', $fieldKey))) {
@@ -42,6 +49,6 @@ class EntityListFieldsContainer
     final public function getFields(): Collection
     {
         return collect($this->fields)
-            ->map(fn (EntityListField $field) => $field->getFieldProperties());
+            ->map(fn (IsEntityListField $field) => $field->getFieldProperties());
     }
 }

--- a/src/EntityList/Fields/EntityListStateField.php
+++ b/src/EntityList/Fields/EntityListStateField.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Code16\Sharp\EntityList\Fields;
+
+class EntityListStateField implements IsEntityListField
+{
+    public function __construct(protected string $label)
+    {
+    }
+
+    public function getFieldProperties(): array
+    {
+        return [
+            'key' => '@state',
+            'label' => $this->label,
+            'sortable' => false,
+            'html' => false,
+            'size' => 'fill',
+            'hideOnXS' => false,
+            'sizeXS' => 'fill',
+        ];
+    }
+}

--- a/src/EntityList/Fields/IsEntityListField.php
+++ b/src/EntityList/Fields/IsEntityListField.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Code16\Sharp\EntityList\Fields;
+
+interface IsEntityListField
+{
+    public function getFieldProperties(): array;
+}

--- a/src/EntityList/SharpEntityList.php
+++ b/src/EntityList/SharpEntityList.php
@@ -58,7 +58,7 @@ abstract class SharpEntityList
         $this->checkListIsBuilt();
 
         return $this->fieldsContainer
-            ->getFields()
+            ->getFields(shouldHaveStateField: !!$this->entityStateAttribute)
             ->toArray();
     }
 

--- a/tests/Unit/EntityList/SharpEntityListStateTest.php
+++ b/tests/Unit/EntityList/SharpEntityListStateTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use Code16\Sharp\EntityList\Fields\EntityListField;
+use Code16\Sharp\EntityList\Fields\EntityListFieldsContainer;
 use Code16\Sharp\Tests\Unit\EntityList\Fakes\FakeEntityState;
 use Code16\Sharp\Tests\Unit\EntityList\Fakes\FakeSharpEntityList;
 
@@ -109,3 +110,71 @@ it('handles authorization in a state', function () {
             'authorization' => [1, 2],
         ]);
 });
+
+it('allows to add state field', function () {
+    $list = new class extends FakeSharpEntityList
+    {
+        public function buildListConfig(): void
+        {
+            $this->configureEntityState('_state', new class extends FakeEntityState
+            {
+                protected function buildStates(): void
+                {
+                    $this->addState('test1', 'Test 1', 'blue');
+                    $this->addState('test2', 'Test 2', 'red');
+                }
+            });
+        }
+        
+        public function buildList(EntityListFieldsContainer $fields): void
+        {
+            $fields->addStateField(label: 'State');
+        }
+    };
+    
+    $list->buildListConfig();
+    
+    expect($list->fields())->toEqual([
+        [
+            'key' => '@state',
+            'label' => 'State',
+            'sortable' => false,
+            'html' => false,
+            'size' => 'fill',
+            'hideOnXS' => false,
+            'sizeXS' => 'fill'
+        ]
+    ]);
+});
+
+it('always sends state field if state configured', function () {
+    $list = new class extends FakeSharpEntityList
+    {
+        public function buildListConfig(): void
+        {
+            $this->configureEntityState('_state', new class extends FakeEntityState
+            {
+                protected function buildStates(): void
+                {
+                    $this->addState('test1', 'Test 1', 'blue');
+                    $this->addState('test2', 'Test 2', 'red');
+                }
+            });
+        }
+    };
+    
+    $list->buildListConfig();
+    
+    expect($list->fields())->toEqual([
+        [
+            'key' => '@state',
+            'label' => '',
+            'sortable' => false,
+            'html' => false,
+            'size' => 'fill',
+            'hideOnXS' => false,
+            'sizeXS' => 'fill'
+        ]
+    ]);
+});
+


### PR DESCRIPTION
## Proposal

### Functional code

```php
class PostList extends SharpEntityList
{
    protected function buildList(EntityListFieldsContainer $fields): void
    {
        $fields
            ->addField(
                EntityListField::make('cover')
                    ->setWidth(1)
            )
            ->addStateField(label: 'State')
            // [...]
    }
    // [...]
}
```

### Data

![image](https://github.com/code16/sharp/assets/973325/67ddc79a-96a6-4bc1-b6fe-f1278715ed66)

### Front behavior

If `key === '@state'` and a if a `state` is configured for this EL, display the state col at this place with the corresponding col label.

If no state is configured, ignore this field (or display an error like missing field in form?)

NB: key is always `@state`, no matter the actual state property name.