### PR TITLE
handles thumbnail usage in views to replicate sharp 8

### DIFF
--- a/src/Form/Eloquent/Uploads/Thumbnails/Thumbnail.php
+++ b/src/Form/Eloquent/Uploads/Thumbnails/Thumbnail.php
@@ -262,4 +262,10 @@ class Thumbnail
         // Strip double /
         return Str::replace('//', '/', $thumbnailPath);
     }
+
+    public function __toString()
+    {
+        // If thumbnail is used in a blade template without parameters, we want to return the URL directly
+        return $this->make();
+    }
 }

--- a/src/Form/Eloquent/Uploads/Thumbnails/Thumbnail.php
+++ b/src/Form/Eloquent/Uploads/Thumbnails/Thumbnail.php
@@ -265,7 +265,7 @@ class Thumbnail
 
     public function __toString()
     {
-        // If thumbnail is used in a blade template without parameters, we want to return the URL directly
+        // Return URL when Thumbnail is used as a string
         return $this->make();
     }
 }

--- a/tests/Unit/Form/Eloquent/Uploads/SharpUploadModelTest.php
+++ b/tests/Unit/Form/Eloquent/Uploads/SharpUploadModelTest.php
@@ -50,7 +50,7 @@ it('allows to display thumbnails with no width or height params', function () {
 
     expect($upload->thumbnail())
         ->toBeInstanceOf(Thumbnail::class)
-        ->and($upload->thumbnail()->__toString())
+        ->and((string) $upload->thumbnail())
         ->toStartWith('/storage/thumbnails/data/-_q-90/'.basename($file));
 });
 

--- a/tests/Unit/Form/Eloquent/Uploads/SharpUploadModelTest.php
+++ b/tests/Unit/Form/Eloquent/Uploads/SharpUploadModelTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use Code16\Sharp\Form\Eloquent\Uploads\SharpUploadModel;
+use Code16\Sharp\Form\Eloquent\Uploads\Thumbnails\Thumbnail;
 use Code16\Sharp\Tests\Fixtures\Person;
 use Illuminate\Support\Facades\Storage;
 
@@ -41,6 +42,16 @@ it('allows to create thumbnails', function () {
         ->toStartWith('/storage/thumbnails/data/-150_q-90/'.basename($file))
         ->and(Storage::disk('public')->exists('thumbnails/data/-150_q-90/'.basename($file)))
         ->toBeTrue();
+});
+
+it('allows to display thumbnails with no width or height params', function () {
+    $file = createImage();
+    $upload = createSharpUploadModel($file);
+
+    expect($upload->thumbnail())
+        ->toBeInstanceOf(Thumbnail::class)
+        ->and($upload->thumbnail()->__toString())
+        ->toStartWith('/storage/thumbnails/data/-_q-90/'.basename($file));
 });
 
 it('returns null on error with a thumbnail creation', function () {


### PR DESCRIPTION
In Sharp 8, you could use thumbnail() without parameters in blade templates and sharp would render it as a string (thumbnail url).

Now with Sharp 9, thumbnail() is fluent and can be chained with other methods (like `addModifier()`). 
When using `->thumbnail()` without parameters, sharp now returns a _Thumbnail_ model. 

This PR tend to replicate previous comportment with fluent Thumbnails, by implementing a __toString() Method in _Thumbnail_ model that executes `->make()`.