### PR TITLE
Fix media migration stubs

### DIFF
--- a/src/Form/Eloquent/Uploads/Migration/uploads.stub
+++ b/src/Form/Eloquent/Uploads/Migration/uploads.stub
@@ -4,7 +4,7 @@ use Illuminate\Support\Facades\Schema;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Migrations\Migration;
 
-class DummyClass extends Migration
+return new class extends Migration
 {
     /**
      * Run the migrations.
@@ -36,4 +36,4 @@ class DummyClass extends Migration
     {
         Schema::dropIfExists('DummyTable');
     }
-}
+};


### PR DESCRIPTION
When using `sharp:create_uploads_migration`, the created migration does not work out of box.