### PR TITLE
Allow string as valid Editor fromFront value?

### DIFF
--- a/src/Form/Fields/Formatters/EditorFormatter.php
+++ b/src/Form/Fields/Formatters/EditorFormatter.php
@@ -41,6 +41,10 @@ class EditorFormatter extends SharpFieldFormatter implements FormatsAfterUpdate
             return null;
         }
 
+        if (is_string($value)) {
+            $value = ['text' => $value];
+        }
+
         $text = $this->maybeLocalized(
             $field,
             $value['text'] ?? null,


### PR DESCRIPTION
Context: allow this in project tests:

```diff
$this
  ->callSharpEntityCommandFromList(
      'posts',
      CancelCommand::class,
-     ['reason' => ['text' => 'Some reason']]
+     ['reason' => 'Some reason']
  )
  ->assertOk();
```