### PR TITLE
Fix CVE-2025-62798: Sanitize HTML content to prevent XSS attacks (for sharp 8.0)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,8 @@
         "intervention/image-laravel": "^1.2",
         "laravel/framework": "^10.0|^11.0",
         "league/commonmark": "^2.4",
-        "spatie/image-optimizer": "^1.6"
+        "spatie/image-optimizer": "^1.6",
+        "symfony/html-sanitizer": "^6.3|^7.0"
     },
     "require-dev": {
         "brianium/paratest": "^6.3|^7.4",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
   },
   "dependencies": {
     "@fortawesome/fontawesome-free": "^6.4.0",
+    "dompurify": "^3.2.0",
     "@tiptap/core": "^2.1.13",
     "@tiptap/extension-character-count": "^2.1.13",
     "@tiptap/extension-code-block": "^2.1.13",

--- a/packages/embeds/src/components/EmbedRenderer.vue
+++ b/packages/embeds/src/components/EmbedRenderer.vue
@@ -7,13 +7,14 @@
     >
         <slot>
             <template v-if="data.slot">
-                <div v-html="data.slot"></div>
+                <div v-html="sanitizedSlot"></div>
             </template>
         </slot>
     </TemplateRenderer>
 </template>
 
 <script>
+    import { sanitize } from "sharp";
     import { TemplateRenderer } from "sharp/components";
 
     export default {
@@ -32,6 +33,9 @@
             templateProps() {
                 return this.options.attributes
                     .filter(attr => attr !== 'slot');
+            },
+            sanitizedSlot() {
+                return sanitize(this.data.slot);
             },
         },
     }

--- a/packages/form/src/components/fields/list/ListUpload.vue
+++ b/packages/form/src/components/fields/list/ListUpload.vue
@@ -34,7 +34,7 @@
 </template>
 
 <script>
-    import { lang } from "sharp";
+    import { lang, sanitize } from "sharp";
 
     export default {
         props: {
@@ -55,9 +55,9 @@
                 }
             },
             text() {
-                return this.getText({
+                return sanitize(this.getText({
                     link: '<a href="#" class="text-reset" tabindex="-1">$1</a>',
-                });
+                }));
             },
             label() {
                 return this.getText();

--- a/packages/search/src/components/GlobalSearch.vue
+++ b/packages/search/src/components/GlobalSearch.vue
@@ -72,7 +72,7 @@
 
 <script>
     import { Modal, Loading } from "sharp-ui";
-    import { lang } from "sharp";
+    import { lang, sanitize } from "sharp";
     import debounce from "lodash/debounce";
     import { getSearchResults } from "../api";
 
@@ -127,12 +127,16 @@
                 this.debouncedGetResults(this.query);
             },
             highlight(text) {
+                // Sanitize input text first to prevent XSS
+                const safeText = sanitize(text) || '';
                 if(this.query?.length) {
-                    return text.replace(new RegExp(this.query, 'gi'), match => {
+                    // Escape regex special characters in query
+                    const escapedQuery = this.query.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+                    return safeText.replace(new RegExp(escapedQuery, 'gi'), match => {
                         return `<mark class="px-0">${match}</mark>`;
                     });
                 }
-                return text;
+                return safeText;
             },
             handleWindowKeydown(event) {
                 const isContentEditable = event.target.isContentEditable || /^(?:input|textarea|select)$/i.test(event.target.tagName);

--- a/packages/show/src/components/fields/text/Text.vue
+++ b/packages/show/src/components/fields/text/Text.vue
@@ -27,6 +27,7 @@
 
 <script>
     import { Localization } from 'sharp/mixins';
+    import { sanitize } from 'sharp';
     import clip from 'text-clipper';
     import { syncVisibility } from "../../../util/fields/visiblity";
     import { truncateToWords, stripTags } from "../../../util/fields/text";
@@ -70,12 +71,12 @@
                     return null;
                 }
                 if(this.hasCollapsed && !this.expanded) {
-                    return this.collapsedContent;
+                    return this.html ? sanitize(this.collapsedContent) : this.collapsedContent;
                 }
                 if(!this.html) {
                     return stripTags(this.resolvedValue).trim();
                 }
-                return this.resolvedValue;
+                return sanitize(this.resolvedValue);
             },
             hasCollapsed() {
                 return !!this.collapsedContent;

--- a/packages/show/src/components/pages/ShowPage.vue
+++ b/packages/show/src/components/pages/ShowPage.vue
@@ -108,7 +108,7 @@
 
 <script>
     import { mapGetters } from 'vuex';
-    import { formUrl, getBackUrl, lang, showAlert, handleNotifications, withLoadingOverlay, showDeleteConfirm } from 'sharp';
+    import { formUrl, getBackUrl, lang, showAlert, handleNotifications, withLoadingOverlay, showDeleteConfirm, sanitize } from 'sharp';
     import { CommandFormModal, CommandViewPanel } from 'sharp-commands';
     import { Grid, GlobalMessage } from 'sharp-ui';
     import { LocaleSelect } from "sharp-form";
@@ -203,10 +203,13 @@
                 if(!this.ready || !this.config.titleAttribute) {
                     return null;
                 }
+                let title;
                 if(this.fields[this.config.titleAttribute]?.localized) {
-                    return this.data[this.config.titleAttribute]?.[this.locale];
+                    title = this.data[this.config.titleAttribute]?.[this.locale];
+                } else {
+                    title = this.data[this.config.titleAttribute];
                 }
-                return this.data[this.config.titleAttribute];
+                return sanitize(title);
             },
             isReordering() {
                 return Object.values(this.reorderingLists).some(reordering => reordering);

--- a/packages/ui/src/components/DataListRow.vue
+++ b/packages/ui/src/components/DataListRow.vue
@@ -23,7 +23,7 @@
                             ]" style="min-width: 0">
                                 <slot name="cell" :row="row" :column="column">
                                     <template v-if="column.html">
-                                        <div v-html="row[column.key]" class="SharpDataList__td-html-container"></div>
+                                        <div v-html="sanitizedHtml(row[column.key])" class="SharpDataList__td-html-container"></div>
                                     </template>
                                     <template v-else>
                                         {{ row[column.key] }}
@@ -52,6 +52,8 @@
 </template>
 
 <script>
+    import { sanitize } from 'sharp';
+
     export default {
         props: {
             columns: Array,
@@ -102,6 +104,9 @@
             },
             toggleHighlight(highlight) {
                 this.isHighlighted = highlight;
+            },
+            sanitizedHtml(html) {
+                return sanitize(html);
             }
         }
     }

--- a/resources/assets/js/components/ActionView.vue
+++ b/resources/assets/js/components/ActionView.vue
@@ -32,7 +32,7 @@
                             <button type="button" class="btn-close" data-test="close-notification" aria-label="Close" @click="close"></button>
                         </div>
                         <template v-if="item.text">
-                            <div class="toast-body" v-html="item.text">
+                            <div class="toast-body" v-html="sanitize(item.text)">
                             </div>
                         </template>
                     </div>
@@ -46,7 +46,7 @@
                     @hidden="dialog.hiddenCallback"
                     :key="dialog.id"
                 >
-                    <div v-html="dialog.text"></div>
+                    <div v-html="sanitize(dialog.text)"></div>
                 </Modal>
             </template>
         </template>
@@ -61,6 +61,7 @@
 
 <script>
     import { createApi } from "../api";
+    import { sanitize } from "../util/sanitize";
     import { Modal, LoadingOverlay, TopBar } from 'sharp-ui';
 
     export default {
@@ -102,6 +103,7 @@
                     }
                 }
             },
+            sanitize,
         },
     }
 </script>

--- a/resources/assets/js/index.js
+++ b/resources/assets/js/index.js
@@ -16,3 +16,4 @@ export { ignoreVueElement } from './util/vue';
 export { formUrl } from 'sharp-form/src/util/url';
 export { showUrl } from 'sharp-show/src/util/url';
 export { listUrl } from 'sharp-entity-list/src/util/url';
+export { sanitize } from './util/sanitize';

--- a/resources/assets/js/util/sanitize.js
+++ b/resources/assets/js/util/sanitize.js
@@ -1,0 +1,18 @@
+import DOMPurify from 'dompurify';
+
+/**
+ * Sanitize HTML content to prevent XSS attacks
+ * @param {string|null} html - The HTML content to sanitize
+ * @returns {string|null} - The sanitized HTML content
+ */
+export function sanitize(html) {
+    if (!html) {
+        return html;
+    }
+    return DOMPurify.sanitize(html, {
+        CUSTOM_ELEMENT_HANDLING: {
+            tagNameCheck: () => true,
+            attributeNameCheck: () => true,
+        }
+    });
+}


### PR DESCRIPTION
As i'm blocked by php 8.2 version on my server here is i hope a fix for the CVE-2025-62798:

- Add symfony/html-sanitizer and dompurify dependencies
- Create sanitize utility function using DOMPurify
- Apply sanitization to all v-html usages:
  - ShowPage title
  - Text field content
  - DataListRow HTML columns
  - ActionView notifications and dialogs
  - EmbedRenderer slots
  - GlobalSearch results
  - ListUpload text