### PR TITLE
Fix CVE-2025-61457: Sanitize SVG files on upload to prevent XSS attacks (for sharp 8.0)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,7 @@
     "require": {
         "php": "8.2.*|8.3.*|8.4.*",
         "code16/laravel-content-renderer": "^1.1.0",
+        "enshrined/svg-sanitize": "^0.21",
         "intervention/image": "^3.4",
         "intervention/image-laravel": "^1.2",
         "laravel/framework": "^10.0|^11.0",

--- a/src/Form/Fields/Utils/SharpFormFieldWithUpload.php
+++ b/src/Form/Fields/Utils/SharpFormFieldWithUpload.php
@@ -15,6 +15,7 @@ trait SharpFormFieldWithUpload
     protected ?bool $transformKeepOriginal = null;
     protected bool $compactThumbnail = false;
     protected bool $shouldOptimizeImage = false;
+    protected bool $shouldSanitizeSvg = true;
     protected string|array|null $fileFilter = null;
 
     public function setMaxFileSize(float $maxFileSizeInMB): self
@@ -50,6 +51,18 @@ trait SharpFormFieldWithUpload
     public function isShouldOptimizeImage(): bool
     {
         return $this->shouldOptimizeImage;
+    }
+
+    public function setSanitizeSvg(bool $shouldSanitizeSvg = true): self
+    {
+        $this->shouldSanitizeSvg = $shouldSanitizeSvg;
+
+        return $this;
+    }
+
+    public function isShouldSanitizeSvg(): bool
+    {
+        return $this->shouldSanitizeSvg;
     }
 
     public function setCompactThumbnail(bool $compactThumbnail = true): self


### PR DESCRIPTION
As i'm blocked by php 8.2 version on my server here is i hope a fix for the CVE-2025-61457 for sharp 8.0:

- Add enshrined/svg-sanitize dependency
- Add setSanitizeSvg() method to SharpFormFieldWithUpload trait (enabled by default)
- Sanitize SVG files in UploadFormatter after storage
- Add tests for SVG sanitization